### PR TITLE
Add Salesforce CLI authentication support and update connection methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An MCP (Model Context Protocol) server implementation that integrates Claude wit
 * **Cross-Object Search**: Search across multiple objects using SOSL
 * **Apex Code Management**: Read, create, and update Apex classes and triggers
 * **Intuitive Error Handling**: Clear feedback with Salesforce-specific error details
+* **Switchable Authentication**: Supports multiple orgs. Easily switch your active Salesforce org based on the default org configured in your VS Code workspace (use Salesforce_CLI authentication for this feature).
 
 ## Installation
 
@@ -141,7 +142,7 @@ Manage debug logs for Salesforce users:
 ## Setup
 
 ### Salesforce Authentication
-You can connect to Salesforce using one of two authentication methods:
+You can connect to Salesforce using one of three authentication methods:
 
 #### 1. Username/Password Authentication (Default)
 1. Set up your Salesforce credentials
@@ -154,9 +155,33 @@ You can connect to Salesforce using one of two authentication methods:
 4. Save the Client ID and Client Secret
 5. **Important**: Note your instance URL (e.g., `https://your-domain.my.salesforce.com`) as it's required for authentication
 
+#### 3. Salesforce CLI Authentication (Recommended for local/dev)
+1. Install and authenticate Salesforce CLI (`sf`).
+2. Make sure your org is authenticated and accessible via `sf org display --json` in the root of your Salesforce project.
+3. The server will automatically retrieve the access token and instance url using the CLI.
+
+
+
 ### Usage with Claude Desktop
 
+
 Add to your `claude_desktop_config.json`:
+
+
+#### For Salesforce CLI Authentication:
+```json
+{
+  "mcpServers": {
+    "salesforce": {
+      "command": "npx",
+      "args": ["-y", "@tsmztech/mcp-server-salesforce"],
+      "env": {
+        "SALESFORCE_CONNECTION_TYPE": "Salesforce_CLI",
+      }
+    }
+  }
+}
+```
 
 #### For Username/Password Authentication:
 ```json

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ You can connect to Salesforce using one of three authentication methods:
 4. Save the Client ID and Client Secret
 5. **Important**: Note your instance URL (e.g., `https://your-domain.my.salesforce.com`) as it's required for authentication
 
-#### 3. Salesforce CLI Authentication (Recommended for local/dev)
+#### 3. Salesforce CLI Authentication (Recommended for local/dev) (contribution by @andrea9293)
 1. Install and authenticate Salesforce CLI (`sf`).
 2. Make sure your org is authenticated and accessible via `sf org display --json` in the root of your Salesforce project.
 3. The server will automatically retrieve the access token and instance url using the CLI.

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -12,7 +12,13 @@ export enum ConnectionType {
    * OAuth 2.0 Client Credentials Flow using client ID and secret
    * Requires SALESFORCE_CLIENT_ID and SALESFORCE_CLIENT_SECRET
    */
-  OAuth_2_0_Client_Credentials = 'OAuth_2.0_Client_Credentials'
+  OAuth_2_0_Client_Credentials = 'OAuth_2.0_Client_Credentials',
+  
+  /**
+   * Salesforce CLI authentication using sf org display command
+   * Requires Salesforce CLI to be installed and an authenticated org
+   */
+  Salesforce_CLI = 'Salesforce_CLI'
 }
 
 /**
@@ -30,4 +36,22 @@ export interface ConnectionConfig {
    * @default 'https://login.salesforce.com'
    */
   loginUrl?: string;
+}
+
+/**
+ * Interface for Salesforce CLI org display response
+ */
+export interface SalesforceCLIResponse {
+  status: number;
+  result: {
+    id: string;
+    apiVersion: string;
+    accessToken: string;
+    instanceUrl: string;
+    username: string;
+    clientId: string;
+    connectedStatus: string;
+    alias?: string;
+  };
+  warnings?: string[];
 }

--- a/src/utils/connection.ts
+++ b/src/utils/connection.ts
@@ -1,7 +1,74 @@
 import jsforce from 'jsforce';
-import { ConnectionType, ConnectionConfig } from '../types/connection.js';
+import { ConnectionType, ConnectionConfig, SalesforceCLIResponse } from '../types/connection.js';
 import https from 'https';
 import querystring from 'querystring';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+/**
+ * Executes the Salesforce CLI command to get org information
+ * @param projectPath Optional path to the Salesforce project root
+ * @returns Parsed response from sf org display --json command
+ */
+async function getSalesforceOrgInfo(): Promise<SalesforceCLIResponse> {
+  try {
+    const command = 'sf org display --json';
+    const options = {};
+    const cwdLog = process.cwd();
+    console.error(`Executing Salesforce CLI command: ${command} in directory: ${cwdLog}`);
+
+    // Use execAsync and handle both success and error cases
+    let stdout = '';
+    let stderr = '';
+    let error: any = null;
+    try {
+      const result = await execAsync(command, options);
+      stdout = result.stdout;
+      stderr = result.stderr;
+    } catch (err: any) {
+      // If the command fails, capture stdout/stderr for diagnostics
+      error = err;
+      stdout = err.stdout || '';
+      stderr = err.stderr || '';
+    }
+
+
+    // Log always the output for debug
+    console.error('[Salesforce CLI] STDOUT:', stdout);
+    if (stderr) {
+      console.warn('[Salesforce CLI] STDERR:', stderr);
+    }
+
+    // Try to parse stdout as JSON
+    let response: SalesforceCLIResponse;
+    try {
+      response = JSON.parse(stdout);
+    } catch (parseErr) {
+      throw new Error(`Failed to parse Salesforce CLI JSON output.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`);
+    }
+
+    // If the command failed (non-zero exit code), throw with details
+    if (error || response.status !== 0) {
+      throw new Error(`Salesforce CLI command failed.\nStatus: ${response.status}\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`);
+    }
+
+    // Accept any org that returns accessToken and instanceUrl
+    if (!response.result || !response.result.accessToken || !response.result.instanceUrl) {
+      throw new Error(`Salesforce CLI did not return accessToken and instanceUrl.\nResult: ${JSON.stringify(response.result)}`);
+    }
+
+    return response;
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.includes('sf: command not found') || error.message.includes("'sf' is not recognized")) {
+        throw new Error('Salesforce CLI (sf) is not installed or not in PATH. Please install the Salesforce CLI to use this authentication method.');
+      }
+    }
+    throw new Error(`Failed to get Salesforce org info: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
 
 /**
  * Creates a Salesforce connection using either username/password or OAuth 2.0 Client Credentials Flow
@@ -86,6 +153,22 @@ export async function createSalesforceConnection(config?: ConnectionConfig) {
         instanceUrl: tokenResponse.instance_url,
         accessToken: tokenResponse.access_token
       });
+      
+      return conn;
+    } else if (connectionType === ConnectionType.Salesforce_CLI) {
+      // Salesforce CLI authentication using sf org display
+      console.error('Connecting to Salesforce using Salesforce CLI authentication');
+      
+      // Execute sf org display --json command
+      const orgInfo = await getSalesforceOrgInfo();
+      
+      // Create connection with the access token from CLI
+      const conn = new jsforce.Connection({
+        instanceUrl: orgInfo.result.instanceUrl,
+        accessToken: orgInfo.result.accessToken
+      });
+      
+      console.error(`Connected to Salesforce org: ${orgInfo.result.username} (${orgInfo.result.alias || 'No alias'})`);
       
       return conn;
     } else {


### PR DESCRIPTION
using sf command, this pr add default org connection without user, pwd and token, only using "sf org display" executed in vs code workspace 