### PR TITLE
Fixed request handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Dependencies
+node_modules
+npm-debug.log
+yarn-error.log
+package-lock.json
+
+# Build output
+dist
+
+# Git
+.git
+.gitignore
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Testing
+test
+coverage
+*.test.js
+*.spec.js
+
+# Documentation
+*.md
+!README.md
+
+# CI/CD
+.github
+.gitlab-ci.yml
+
+# Other
+.DS_Store
+Thumbs.db
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-# Use Node.js 18 Alpine for smaller image size
+# Use Node.js 22 Alpine for smaller image size
 FROM node:22-alpine
+
 # Set working directory
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Use Node.js 18 Alpine for smaller image size
+FROM node:22-alpine
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Copy source code
+COPY . .
+
+# Install dependencies
+RUN npm install
+
+# Build the application
+RUN npm run build
+
+# Expose port
+EXPOSE 3000
+
+# Start the application
+CMD ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
   "author": "tsmztech",
   "license": "MIT",
   "dependencies": {
-      "@modelcontextprotocol/sdk": "1.17.3",
-      "dotenv": "^16.3.1",
-      "jsforce": "^1.11.0"
+    "@modelcontextprotocol/sdk": "1.17.3",
+    "dotenv": "^16.3.1",
+    "express": "^4.21.2",
+    "jsforce": "^1.11.0"
   },
   "devDependencies": {
       "@types/express": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -1,39 +1,39 @@
 {
-    "name": "@tsmztech/mcp-server-salesforce",
-    "version": "0.0.3",
-    "description": "A Salesforce connector MCP Server.",
-    "main": "dist/index.js",
-    "types": "dist/index.d.ts",
-    "type": "module",
-    "bin": {
+  "name": "@tsmztech/mcp-server-salesforce",
+  "version": "0.0.3",
+  "description": "A Salesforce connector MCP Server.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "bin": {
       "salesforce-connector": "dist/index.js"
-    },
-    "files": [
+  },
+  "files": [
       "dist"
-    ],
-    "scripts": {
+  ],
+  "scripts": {
       "build": "tsc && shx chmod +x dist/*.js",
       "prepare": "npm run build",
       "watch": "tsc --watch",
       "test": "node --test"
-    },
-    "keywords": [
+  },
+  "keywords": [
       "mcp",
       "salesforce",
       "claude",
       "ai"
-    ],
-    "author": "tsmztech",
-    "license": "MIT",
-    "dependencies": {
-      "@modelcontextprotocol/sdk": "0.5.0",
+  ],
+  "author": "tsmztech",
+  "license": "MIT",
+  "dependencies": {
+      "@modelcontextprotocol/sdk": "1.17.3",
       "dotenv": "^16.3.1",
       "jsforce": "^1.11.0"
-    },
-    "devDependencies": {
+  },
+  "devDependencies": {
+      "@types/express": "^5.0.3",
       "@types/node": "^22.10.1",
-      "typescript": "^5.7.2",
-      "shx": "^0.3.4"
-    }
+      "shx": "^0.3.4",
+      "typescript": "^5.7.2"
   }
-  
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,10 @@ function logToolResponse(toolName: string, result: any) {
       result.content.forEach((content: any, index: number) => {
         if (content.type === 'text') {
           const text = content.text;
-          const preview = text.length > 500 ? text.substring(0, 500) + '...[truncated]' : text;
+          // Show more content for schema/describe responses, less for data queries
+          const isSchemaResponse = text.includes('Object:') && text.includes('Fields:');
+          const previewLength = isSchemaResponse ? 2000 : 800;
+          const preview = text.length > previewLength ? text.substring(0, previewLength) + '...[truncated]' : text;
           console.log(`[MCP] Response content[${index}]:`, preview);
           console.log(`[MCP] Full response length:`, text.length, 'characters');
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ const WRITE_TOOLS = [
   MANAGE_FIELD,
   MANAGE_FIELD_PERMISSIONS,
   MANAGE_DEBUG_LOGS,
+  READ_APEX,
   WRITE_APEX,
   READ_APEX_TRIGGER,
   WRITE_APEX_TRIGGER,
@@ -349,11 +350,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 const app = express();
 app.use(express.json());
 
-// Map to store transports by session ID
-const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
+// Remove unused transports map - not needed in stateless mode
 
 app.post('/mcp', async (req: Request, res: Response) => {
-  // In stateless mode, create a new instance of transport and server for each request
+  // In stateless mode, create a new instance of transport for each request
   // to ensure complete isolation. A single instance would cause request ID collisions
   // when multiple clients connect concurrently.
   
@@ -361,12 +361,300 @@ app.post('/mcp', async (req: Request, res: Response) => {
     const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
     });
+    
+    // Create a new server instance for this request to avoid conflicts
+    const requestServer = new Server(
+      {
+        name: "salesforce-mcp-server",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      },
+    );
+
+    // Set up request handlers for this server instance
+    requestServer.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: getTools(),
+    }));
+
+    requestServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+      try {
+        const { name, arguments: args } = request.params;
+        if (!args) throw new Error('Arguments are required');
+
+        console.log(`[MCP] Processing tool: ${name}`);
+        const conn = await createSalesforceConnection();
+        console.log(`[MCP] Salesforce connection established for tool: ${name}`);
+
+        switch (name) {
+          case "salesforce_search_objects": {
+            const { searchPattern } = args as { searchPattern: string };
+            if (!searchPattern) throw new Error('searchPattern is required');
+            return await handleSearchObjects(conn, searchPattern);
+          }
+
+          case "salesforce_describe_object": {
+            const { objectName } = args as { objectName: string };
+            if (!objectName) throw new Error('objectName is required');
+            return await handleDescribeObject(conn, objectName);
+          }
+
+          case "salesforce_query_records": {
+            const queryArgs = args as Record<string, unknown>;
+            if (!queryArgs.objectName || !Array.isArray(queryArgs.fields)) {
+              throw new Error('objectName and fields array are required for query');
+            }
+            const validatedArgs: QueryArgs = {
+              objectName: queryArgs.objectName as string,
+              fields: queryArgs.fields as string[],
+              whereClause: queryArgs.whereClause as string | undefined,
+              orderBy: queryArgs.orderBy as string | undefined,
+              limit: queryArgs.limit as number | undefined
+            };
+            return await handleQueryRecords(conn, validatedArgs);
+          }
+
+          case "salesforce_aggregate_query": {
+            const aggregateArgs = args as Record<string, unknown>;
+            if (!aggregateArgs.objectName || !Array.isArray(aggregateArgs.selectFields) || !Array.isArray(aggregateArgs.groupByFields)) {
+              throw new Error('objectName, selectFields array, and groupByFields array are required for aggregate query');
+            }
+            const validatedArgs: AggregateQueryArgs = {
+              objectName: aggregateArgs.objectName as string,
+              selectFields: aggregateArgs.selectFields as string[],
+              groupByFields: aggregateArgs.groupByFields as string[],
+              whereClause: aggregateArgs.whereClause as string | undefined,
+              havingClause: aggregateArgs.havingClause as string | undefined,
+              orderBy: aggregateArgs.orderBy as string | undefined,
+              limit: aggregateArgs.limit as number | undefined
+            };
+            return await handleAggregateQuery(conn, validatedArgs);
+          }
+
+          case "salesforce_dml_records": {
+            const dmlArgs = args as Record<string, unknown>;
+            if (!dmlArgs.operation || !dmlArgs.objectName || !Array.isArray(dmlArgs.records)) {
+              throw new Error('operation, objectName, and records array are required for DML');
+            }
+            const validatedArgs: DMLArgs = {
+              operation: dmlArgs.operation as 'insert' | 'update' | 'delete' | 'upsert',
+              objectName: dmlArgs.objectName as string,
+              records: dmlArgs.records as Record<string, any>[],
+              externalIdField: dmlArgs.externalIdField as string | undefined
+            };
+            return await handleDMLRecords(conn, validatedArgs);
+          }
+
+          case "salesforce_manage_object": {
+            const objectArgs = args as Record<string, unknown>;
+            if (!objectArgs.operation || !objectArgs.objectName) {
+              throw new Error('operation and objectName are required for object management');
+            }
+            const validatedArgs: ManageObjectArgs = {
+              operation: objectArgs.operation as 'create' | 'update',
+              objectName: objectArgs.objectName as string,
+              label: objectArgs.label as string | undefined,
+              pluralLabel: objectArgs.pluralLabel as string | undefined,
+              description: objectArgs.description as string | undefined,
+              nameFieldLabel: objectArgs.nameFieldLabel as string | undefined,
+              nameFieldType: objectArgs.nameFieldType as 'Text' | 'AutoNumber' | undefined,
+              nameFieldFormat: objectArgs.nameFieldFormat as string | undefined,
+              sharingModel: objectArgs.sharingModel as 'ReadWrite' | 'Read' | 'Private' | 'ControlledByParent' | undefined
+            };
+            return await handleManageObject(conn, validatedArgs);
+          }
+
+          case "salesforce_manage_field": {
+            const fieldArgs = args as Record<string, unknown>;
+            if (!fieldArgs.operation || !fieldArgs.objectName || !fieldArgs.fieldName) {
+              throw new Error('operation, objectName, and fieldName are required for field management');
+            }
+            const validatedArgs: ManageFieldArgs = {
+              operation: fieldArgs.operation as 'create' | 'update',
+              objectName: fieldArgs.objectName as string,
+              fieldName: fieldArgs.fieldName as string,
+              label: fieldArgs.label as string | undefined,
+              type: fieldArgs.type as string | undefined,
+              required: fieldArgs.required as boolean | undefined,
+              unique: fieldArgs.unique as boolean | undefined,
+              externalId: fieldArgs.externalId as boolean | undefined,
+              length: fieldArgs.length as number | undefined,
+              precision: fieldArgs.precision as number | undefined,
+              scale: fieldArgs.scale as number | undefined,
+              referenceTo: fieldArgs.referenceTo as string | undefined,
+              relationshipLabel: fieldArgs.relationshipLabel as string | undefined,
+              relationshipName: fieldArgs.relationshipName as string | undefined,
+              deleteConstraint: fieldArgs.deleteConstraint as 'Cascade' | 'Restrict' | 'SetNull' | undefined,
+              picklistValues: fieldArgs.picklistValues as Array<{ label: string; isDefault?: boolean }> | undefined,
+              description: fieldArgs.description as string | undefined,
+              grantAccessTo: fieldArgs.grantAccessTo as string[] | undefined
+            };
+            return await handleManageField(conn, validatedArgs);
+          }
+
+          case "salesforce_manage_field_permissions": {
+            const permArgs = args as Record<string, unknown>;
+            if (!permArgs.operation || !permArgs.objectName || !permArgs.fieldName) {
+              throw new Error('operation, objectName, and fieldName are required for field permissions management');
+            }
+            const validatedArgs: ManageFieldPermissionsArgs = {
+              operation: permArgs.operation as 'grant' | 'revoke' | 'view',
+              objectName: permArgs.objectName as string,
+              fieldName: permArgs.fieldName as string,
+              profileNames: permArgs.profileNames as string[] | undefined,
+              readable: permArgs.readable as boolean | undefined,
+              editable: permArgs.editable as boolean | undefined
+            };
+            return await handleManageFieldPermissions(conn, validatedArgs);
+          }
+
+          case "salesforce_search_all": {
+            const searchArgs = args as Record<string, unknown>;
+            if (!searchArgs.searchTerm || !Array.isArray(searchArgs.objects)) {
+              throw new Error('searchTerm and objects array are required for search');
+            }
+
+            const objects = searchArgs.objects as Array<Record<string, unknown>>;
+            if (!objects.every(obj => obj.name && Array.isArray(obj.fields))) {
+              throw new Error('Each object must specify name and fields array');
+            }
+
+            const validatedArgs: SearchAllArgs = {
+              searchTerm: searchArgs.searchTerm as string,
+              searchIn: searchArgs.searchIn as "ALL FIELDS" | "NAME FIELDS" | "EMAIL FIELDS" | "PHONE FIELDS" | "SIDEBAR FIELDS" | undefined,
+              objects: objects.map(obj => ({
+                name: obj.name as string,
+                fields: obj.fields as string[],
+                where: obj.where as string | undefined,
+                orderBy: obj.orderBy as string | undefined,
+                limit: obj.limit as number | undefined
+              })),
+              withClauses: searchArgs.withClauses as WithClause[] | undefined,
+              updateable: searchArgs.updateable as boolean | undefined,
+              viewable: searchArgs.viewable as boolean | undefined
+            };
+
+            return await handleSearchAll(conn, validatedArgs);
+          }
+
+          case "salesforce_read_apex": {
+            const apexArgs = args as Record<string, unknown>;
+            
+            const validatedArgs: ReadApexArgs = {
+              className: apexArgs.className as string | undefined,
+              namePattern: apexArgs.namePattern as string | undefined,
+              includeMetadata: apexArgs.includeMetadata as boolean | undefined
+            };
+
+            return await handleReadApex(conn, validatedArgs);
+          }
+
+          case "salesforce_write_apex": {
+            const apexArgs = args as Record<string, unknown>;
+            if (!apexArgs.operation || !apexArgs.className || !apexArgs.body) {
+              throw new Error('operation, className, and body are required for writing Apex');
+            }
+            
+            const validatedArgs: WriteApexArgs = {
+              operation: apexArgs.operation as 'create' | 'update',
+              className: apexArgs.className as string,
+              apiVersion: apexArgs.apiVersion as string | undefined,
+              body: apexArgs.body as string
+            };
+
+            return await handleWriteApex(conn, validatedArgs);
+          }
+
+          case "salesforce_read_apex_trigger": {
+            const triggerArgs = args as Record<string, unknown>;
+            
+            const validatedArgs: ReadApexTriggerArgs = {
+              triggerName: triggerArgs.triggerName as string | undefined,
+              namePattern: triggerArgs.namePattern as string | undefined,
+              includeMetadata: triggerArgs.includeMetadata as boolean | undefined
+            };
+
+            return await handleReadApexTrigger(conn, validatedArgs);
+          }
+
+          case "salesforce_write_apex_trigger": {
+            const triggerArgs = args as Record<string, unknown>;
+            if (!triggerArgs.operation || !triggerArgs.triggerName || !triggerArgs.body) {
+              throw new Error('operation, triggerName, and body are required for writing Apex trigger');
+            }
+            
+            const validatedArgs: WriteApexTriggerArgs = {
+              operation: triggerArgs.operation as 'create' | 'update',
+              triggerName: triggerArgs.triggerName as string,
+              objectName: triggerArgs.objectName as string | undefined,
+              apiVersion: triggerArgs.apiVersion as string | undefined,
+              body: triggerArgs.body as string
+            };
+
+            return await handleWriteApexTrigger(conn, validatedArgs);
+          }
+
+          case "salesforce_execute_anonymous": {
+            const executeArgs = args as Record<string, unknown>;
+            if (!executeArgs.apexCode) {
+              throw new Error('apexCode is required for executing anonymous Apex');
+            }
+            
+            const validatedArgs: ExecuteAnonymousArgs = {
+              apexCode: executeArgs.apexCode as string,
+              logLevel: executeArgs.logLevel as 'NONE' | 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'FINE' | 'FINER' | 'FINEST' | undefined
+            };
+
+            return await handleExecuteAnonymous(conn, validatedArgs);
+          }
+
+          case "salesforce_manage_debug_logs": {
+            const debugLogsArgs = args as Record<string, unknown>;
+            if (!debugLogsArgs.operation || !debugLogsArgs.username) {
+              throw new Error('operation and username are required for managing debug logs');
+            }
+            
+            const validatedArgs: ManageDebugLogsArgs = {
+              operation: debugLogsArgs.operation as 'enable' | 'disable' | 'retrieve',
+              username: debugLogsArgs.username as string,
+              logLevel: debugLogsArgs.logLevel as 'NONE' | 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'FINE' | 'FINER' | 'FINEST' | undefined,
+              expirationTime: debugLogsArgs.expirationTime as number | undefined,
+              limit: debugLogsArgs.limit as number | undefined,
+              logId: debugLogsArgs.logId as string | undefined,
+              includeBody: debugLogsArgs.includeBody as boolean | undefined
+            };
+
+            return await handleManageDebugLogs(conn, validatedArgs);
+          }
+
+          default:
+            return {
+              content: [{ type: "text", text: `Unknown tool: ${name}` }],
+              isError: true,
+            };
+        }
+      } catch (error) {
+        console.error(`[MCP] Error in tool ${request.params.name}:`, error);
+        return {
+          content: [{
+            type: "text",
+            text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+          }],
+          isError: true,
+        };
+      }
+    });
+    
     res.on('close', () => {
       console.log('Request closed');
       transport.close();
-      server.close();
+      // Don't close the main server - only close the transport
     });
-    await server.connect(transport);
+    
+    await requestServer.connect(transport);
     await transport.handleRequest(req, res, req.body);
   } catch (error) {
     console.error('Error handling MCP request:', error);
@@ -383,48 +671,52 @@ app.post('/mcp', async (req: Request, res: Response) => {
   }
 });
 
+// Health check endpoint
+app.get('/health', async (req: Request, res: Response) => {
+  try {
+    const conn = await createSalesforceConnection();
+    await conn.query('SELECT Id FROM User LIMIT 1');
+    res.json({ 
+      status: 'healthy', 
+      timestamp: new Date().toISOString(),
+      salesforce: 'connected'
+    });
+  } catch (error) {
+    console.error('Health check failed:', error);
+    res.status(500).json({ 
+      status: 'unhealthy', 
+      error: error instanceof Error ? error.message : String(error),
+      timestamp: new Date().toISOString(),
+      salesforce: 'disconnected'
+    });
+  }
+});
+
 // SSE notifications not supported in stateless mode
 app.get('/mcp', async (req: Request, res: Response) => {
-  console.log('Received GET MCP request');
-  res.writeHead(405).end(JSON.stringify({
+  console.log('Received GET MCP request - Method not allowed in stateless mode');
+  res.status(405).json({
     jsonrpc: "2.0",
     error: {
       code: -32000,
-      message: "Method not allowed."
+      message: "GET method not supported in stateless mode. Use POST /mcp for requests."
     },
     id: null
-  }));
+  });
 });
 
 // Session termination not needed in stateless mode
 app.delete('/mcp', async (req: Request, res: Response) => {
-  console.log('Received DELETE MCP request');
-  res.writeHead(405).end(JSON.stringify({
+  console.log('Received DELETE MCP request - Method not allowed in stateless mode');
+  res.status(405).json({
     jsonrpc: "2.0",
     error: {
       code: -32000,
-      message: "Method not allowed."
+      message: "DELETE method not supported in stateless mode. Use POST /mcp for requests."
     },
     id: null
-  }));
+  });
 });
-// Reusable handler for GET and DELETE requests
-const handleSessionRequest = async (req: express.Request, res: express.Response) => {
-  const sessionId = req.headers['mcp-session-id'] as string | undefined;
-  if (!sessionId || !transports[sessionId]) {
-    res.status(400).send('Invalid or missing session ID');
-    return;
-  }
-  
-  const transport = transports[sessionId];
-  await transport.handleRequest(req, res);
-};
-
-// Handle GET requests for server-to-client notifications via SSE
-app.get('/mcp', handleSessionRequest);
-
-// Handle DELETE requests for session termination
-app.delete('/mcp', handleSessionRequest);
 
 app.listen(3000, () => {
   console.log("Salesforce MCP Server running on http://localhost:3000");

--- a/src/tools/describe.ts
+++ b/src/tools/describe.ts
@@ -19,16 +19,47 @@ export const DESCRIBE_OBJECT: Tool = {
 export async function handleDescribeObject(conn: any, objectName: string) {
   const describe = await conn.describe(objectName) as SalesforceDescribeResponse;
   
-  // Format the output
+  console.log(`[DESCRIBE] Object ${objectName} has ${describe.fields.length} fields`);
+  
+  // Separate fields by type for better organization
+  const standardFields = describe.fields.filter(f => !f.name.includes('__c') && !f.name.includes('__r'));
+  const customFields = describe.fields.filter(f => f.name.includes('__c'));
+  const relationshipFields = describe.fields.filter(f => f.referenceTo && f.referenceTo.length > 0);
+  
+  console.log(`[DESCRIBE] ${standardFields.length} standard, ${customFields.length} custom, ${relationshipFields.length} relationship fields`);
+  
+  // Format the output with better organization
   const formattedDescription = `
 Object: ${describe.name} (${describe.label})${describe.custom ? ' (Custom Object)' : ''}
-Fields:
-${describe.fields.map((field: SalesforceField) => `  - ${field.name} (${field.label})
+
+STANDARD FIELDS (${standardFields.length}):
+${standardFields.slice(0, 20).map((field: SalesforceField) => `  - ${field.name} (${field.label})
+    Type: ${field.type}${field.length ? `, Length: ${field.length}` : ''}
+    Required: ${!field.nillable}
+    ${field.picklistValues && field.picklistValues.length > 0 ? `Picklist Values: ${field.picklistValues.map((v: { value: string }) => v.value).join(', ')}` : ''}`
+  ).join('\n')}${standardFields.length > 20 ? `\n  ... and ${standardFields.length - 20} more standard fields` : ''}
+
+RELATIONSHIP FIELDS (${relationshipFields.length}):
+${relationshipFields.slice(0, 10).map((field: SalesforceField) => `  - ${field.name} (${field.label})
+    Type: ${field.type} → References: ${field.referenceTo.join(', ')}
+    Required: ${!field.nillable}`
+  ).join('\n')}${relationshipFields.length > 10 ? `\n  ... and ${relationshipFields.length - 10} more relationship fields` : ''}
+
+CUSTOM FIELDS (${customFields.length}):
+${customFields.slice(0, 15).map((field: SalesforceField) => `  - ${field.name} (${field.label})
     Type: ${field.type}${field.length ? `, Length: ${field.length}` : ''}
     Required: ${!field.nillable}
     ${field.referenceTo && field.referenceTo.length > 0 ? `References: ${field.referenceTo.join(', ')}` : ''}
     ${field.picklistValues && field.picklistValues.length > 0 ? `Picklist Values: ${field.picklistValues.map((v: { value: string }) => v.value).join(', ')}` : ''}`
-  ).join('\n')}`;
+  ).join('\n')}${customFields.length > 15 ? `\n  ... and ${customFields.length - 15} more custom fields` : ''}
+
+RECOMMENDED QUERY FIELDS FOR ${objectName.toUpperCase()}:
+${objectName === 'Opportunity' ? 
+  '  - Basic: ["Id", "Name", "StageName", "Amount", "CloseDate", "CreatedDate", "LastModifiedDate"]\n  - With Account: ["Id", "Name", "StageName", "Amount", "Account.Name", "Account.Industry", "Account.Type"]\n  - Full Pipeline: ["Id", "Name", "StageName", "Amount", "CloseDate", "CreatedDate", "Account.Name", "Owner.Name", "LeadSource"]' :
+objectName === 'Account' ?
+  '  - Basic: ["Id", "Name", "Industry", "Type", "CreatedDate", "LastModifiedDate"]\n  - With Owner: ["Id", "Name", "Industry", "Type", "Owner.Name", "Owner.Email"]\n  - Full Details: ["Id", "Name", "Industry", "Type", "BillingCity", "BillingState", "Phone", "Website"]' :
+  '  - Use field names from the lists above in your queries'
+}`;
 
   return {
     content: [{


### PR DESCRIPTION
1. Fixed bug with request closer. It no longer shuts down the server after tool so when making a second tool call before the server starts up again throws an error. Did this by changing server instance and lifecycle since we just have the server deployed anyway. 
2. Adjusted schema ranges so that it includes opportunity from 'today' when querying for something like 'last week'
3. Fixed issue with request ID collisions with the async call.
4. Added more info on the schema for the agent. Before responses were truncated at 500 characters, the agent couldn't see available fields, and added some better field errors
5. Added some logging too
