### PR TITLE
feat(query): add utility to conditionally allow optional schema keywords

### DIFF
--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -1,5 +1,10 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 
+// Utility to check if optional schema keyword is allowed
+function isOptionalSchemaAllowed() {
+  return process.env.SALESFORCE_OPTIONAL_SCHEMA_KEYWORD_ALLOW === "true";
+}
+
 export const QUERY_RECORDS: Tool = {
   name: "salesforce_query_records",
   description: `Query records from any Salesforce object using SOQL, including relationship queries.
@@ -40,21 +45,18 @@ Note: When using relationship fields:
         items: { type: "string" },
         description: "List of fields to retrieve, including relationship fields"
       },
-      whereClause: {
+      whereClause: Object.assign({
         type: "string",
-        description: "WHERE clause, can include conditions on related objects",
-        optional: true
-      },
-      orderBy: {
+        description: "WHERE clause, can include conditions on related objects"
+      }, isOptionalSchemaAllowed() ? { optional: true } : {}),
+      orderBy: Object.assign({
         type: "string",
-        description: "ORDER BY clause, can include fields from related objects",
-        optional: true
-      },
-      limit: {
+        description: "ORDER BY clause, can include fields from related objects"
+      }, isOptionalSchemaAllowed() ? { optional: true } : {}),
+      limit: Object.assign({
         type: "number",
-        description: "Maximum number of records to return",
-        optional: true
-      }
+        description: "Maximum number of records to return"
+      }, isOptionalSchemaAllowed() ? { optional: true } : {})
     },
     required: ["objectName", "fields"]
   }


### PR DESCRIPTION
This pull request introduces a utility function to conditionally allow the use of the optional schema keyword for certain fields in the Salesforce query tool, based on an environment variable. The main changes revolve around making the `whereClause`, `orderBy`, and `limit` fields optionally marked as optional in the schema, depending on the environment configuration.

Conditional schema option support:

* Added the `isOptionalSchemaAllowed` utility function to check if the environment variable `SALESFORCE_OPTIONAL_SCHEMA_KEYWORD_ALLOW` is set to "true". (`src/tools/query.ts`)
* Updated the schema definitions for `whereClause`, `orderBy`, and `limit` in the `QUERY_RECORDS` tool to conditionally include the `optional: true` property if allowed by the environment variable. (`src/tools/query.ts`)

This was implemented to address the issue with requests failing when requiring a strict Schema.