### PR TITLE
feat: add REST API passthrough tool (salesforce_rest_api)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An MCP (Model Context Protocol) server implementation that integrates Claude wit
 * **Data Manipulation**: Insert, update, delete, and upsert records with ease
 * **Cross-Object Search**: Search across multiple objects using SOSL
 * **Apex Code Management**: Read, create, and update Apex classes and triggers
+* **REST API Passthrough**: Call any Salesforce REST endpoint directly — Reports, Composite API, Files, Limits, and more
 * **Intuitive Error Handling**: Clear feedback with Salesforce-specific error details
 * **Switchable Authentication**: Supports multiple orgs. Easily switch your active Salesforce org based on the default org configured in your VS Code workspace (use Salesforce_CLI authentication for this feature).
 
@@ -153,6 +154,22 @@ Manage debug logs for Salesforce users:
 * Retrieve and view debug logs
 * Configure log levels (NONE, ERROR, WARN, INFO, DEBUG, FINE, FINER, FINEST)
 * Example: "Enable debug logs for user@example.com" or "Retrieve recent logs for an admin user"
+
+### salesforce_rest_api
+Make direct REST API calls to any Salesforce REST endpoint:
+* Access any Salesforce REST API endpoint not covered by other tools
+* Supports GET, POST, PATCH, PUT, and DELETE methods
+* Automatically handles API version prefixing (`/services/data/vXX.0/`)
+* Supports raw paths for custom Apex REST endpoints (`/services/apexrest/...`)
+* Query parameters and JSON request bodies
+* Configurable API version override
+* Large response truncation to prevent client overload
+* Examples:
+  - "Get our org's API limits" → `GET /limits`
+  - "Run report 00O5e000004XXXX" → `GET /analytics/reports/{id}`
+  - "Get the Composite API to batch requests" → `POST /composite`
+  - "Download file content" → `GET /sobjects/ContentVersion/{id}/VersionData`
+  - "Call our custom Apex REST endpoint" → `GET /services/apexrest/MyEndpoint` (with `rawPath: true`)
 
 ## Setup
 
@@ -328,6 +345,15 @@ Examples with Field Level Security:
 "Retrieve recent logs for an admin user"
 "Disable debug logs for a specific user"
 "Configure log level to DEBUG for a user"
+```
+
+### REST API Calls
+```
+"Check our org's API usage limits"
+"Run the weekly sales report"
+"Get all available REST API resources"
+"Call our custom Apex REST endpoint at /services/apexrest/AccountSync"
+"Use the Composite API to create an Account and Contact in one call"
 ```
 
 ## Development

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { READ_APEX_TRIGGER, handleReadApexTrigger, ReadApexTriggerArgs } from ".
 import { WRITE_APEX_TRIGGER, handleWriteApexTrigger, WriteApexTriggerArgs } from "./tools/writeApexTrigger.js";
 import { EXECUTE_ANONYMOUS, handleExecuteAnonymous, ExecuteAnonymousArgs } from "./tools/executeAnonymous.js";
 import { MANAGE_DEBUG_LOGS, handleManageDebugLogs, ManageDebugLogsArgs } from "./tools/manageDebugLogs.js";
+import { REST_API, handleRestApi, RestApiArgs } from "./tools/restApi.js";
 
 // Load environment variables (using dotenv 16.x which has no stdout tips)
 // MCP servers require stdout to contain ONLY JSON-RPC messages
@@ -58,7 +59,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     READ_APEX_TRIGGER,
     WRITE_APEX_TRIGGER,
     EXECUTE_ANONYMOUS,
-    MANAGE_DEBUG_LOGS
+    MANAGE_DEBUG_LOGS,
+    REST_API
   ],
 }));
 
@@ -318,6 +320,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
 
         return await handleManageDebugLogs(conn, validatedArgs);
+      }
+
+      case "salesforce_rest_api": {
+        const restArgs = args as Record<string, unknown>;
+        if (!restArgs.method || !restArgs.endpoint) {
+          throw new Error('method and endpoint are required for REST API calls');
+        }
+        const validatedArgs: RestApiArgs = {
+          method: restArgs.method as "GET" | "POST" | "PATCH" | "PUT" | "DELETE",
+          endpoint: restArgs.endpoint as string,
+          body: restArgs.body as Record<string, any> | undefined,
+          queryParameters: restArgs.queryParameters as Record<string, string> | undefined,
+          apiVersion: restArgs.apiVersion as string | undefined,
+          rawPath: restArgs.rawPath as boolean | undefined
+        };
+        return await handleRestApi(conn, validatedArgs);
       }
 
       default:

--- a/src/tools/restApi.ts
+++ b/src/tools/restApi.ts
@@ -1,0 +1,170 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const REST_API: Tool = {
+  name: "salesforce_rest_api",
+  description: `Make direct REST API calls to any Salesforce REST endpoint. This is a powerful passthrough tool that gives access to the full Salesforce REST API surface — including endpoints not covered by other tools.
+
+Use this for any Salesforce REST API that doesn't have a dedicated tool, such as:
+- Reports and Dashboards API: GET /analytics/reports/{reportId}
+- Composite API: POST /composite
+- Files and ContentDocument: GET /sobjects/ContentDocument/{id}/VersionData
+- Approval Processes: POST /process/approvals
+- Limits and Usage: GET /limits
+- Tabs and Themes: GET /tabs, GET /theme
+- Quick Actions: GET /sobjects/{object}/quickActions
+- Any custom REST endpoint
+
+The endpoint path is relative to /services/data/vXX.0/ (the API version prefix is added automatically).
+
+Examples:
+1. Get org limits:
+   - method: "GET"
+   - endpoint: "/limits"
+
+2. Run a report:
+   - method: "GET"
+   - endpoint: "/analytics/reports/00O5e000004XXXXEAA"
+
+3. Composite request (multiple operations in one call):
+   - method: "POST"
+   - endpoint: "/composite"
+   - body: { "allOrNone": true, "compositeRequest": [...] }
+
+4. Get file content:
+   - method: "GET"
+   - endpoint: "/sobjects/ContentVersion/068XXXXXXXXXXXXXXX/VersionData"
+
+5. Call a custom REST endpoint:
+   - method: "GET"
+   - endpoint: "/my-custom-endpoint"
+   - rawPath: true
+
+6. Use a specific API version:
+   - method: "GET"
+   - endpoint: "/limits"
+   - apiVersion: "59.0"`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      method: {
+        type: "string",
+        description: "HTTP method: GET, POST, PATCH, PUT, or DELETE",
+        enum: ["GET", "POST", "PATCH", "PUT", "DELETE"]
+      },
+      endpoint: {
+        type: "string",
+        description: "REST API endpoint path relative to /services/data/vXX.0/ (e.g., '/limits', '/analytics/reports/{id}'). If rawPath is true, this is the full path from root (e.g., '/services/apexrest/my-endpoint')."
+      },
+      body: {
+        type: "object",
+        description: "Request body for POST, PATCH, and PUT requests. Will be serialized as JSON.",
+        optional: true
+      },
+      queryParameters: {
+        type: "object",
+        description: "URL query parameters as key-value pairs (e.g., { \"includeDetails\": \"true\" })",
+        optional: true
+      },
+      apiVersion: {
+        type: "string",
+        description: "Override the Salesforce API version (e.g., '59.0', '60.0'). Defaults to the connection's API version.",
+        optional: true
+      },
+      rawPath: {
+        type: "boolean",
+        description: "If true, the endpoint is treated as a full absolute path from the instance root (e.g., '/services/apexrest/MyEndpoint') instead of being prefixed with /services/data/vXX.0/. Default: false.",
+        optional: true
+      }
+    },
+    required: ["method", "endpoint"]
+  }
+};
+
+export interface RestApiArgs {
+  method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+  endpoint: string;
+  body?: Record<string, any>;
+  queryParameters?: Record<string, string>;
+  apiVersion?: string;
+  rawPath?: boolean;
+}
+
+export async function handleRestApi(conn: any, args: RestApiArgs) {
+  const { method, endpoint, body, queryParameters, apiVersion, rawPath } = args;
+
+  try {
+    // Build the full URL path
+    let url: string;
+    if (rawPath) {
+      url = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+    } else {
+      const version = apiVersion || conn.version || '59.0';
+      const cleanEndpoint = endpoint.startsWith('/') ? endpoint : `/${endpoint}`;
+      url = `/services/data/v${version}${cleanEndpoint}`;
+    }
+
+    // Append query parameters
+    if (queryParameters && Object.keys(queryParameters).length > 0) {
+      const params = new URLSearchParams(queryParameters).toString();
+      url += (url.includes('?') ? '&' : '?') + params;
+    }
+
+    // Build the request options
+    const requestOptions: any = {
+      method,
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      }
+    };
+
+    if (body && (method === 'POST' || method === 'PATCH' || method === 'PUT')) {
+      requestOptions.body = JSON.stringify(body);
+    }
+
+    // Execute the request using jsforce's built-in HTTP client
+    const response = await conn.request(requestOptions);
+
+    // Format the response
+    const responseText = typeof response === 'string'
+      ? response
+      : JSON.stringify(response, null, 2);
+
+    // Truncate very large responses to avoid overwhelming the client
+    const maxLength = 50000;
+    const truncated = responseText.length > maxLength;
+    const displayText = truncated
+      ? responseText.substring(0, maxLength) + `\n\n... (truncated, ${responseText.length} total characters)`
+      : responseText;
+
+    return {
+      content: [{
+        type: "text",
+        text: `${method} ${url} — Success\n\n${displayText}`
+      }],
+      isError: false,
+    };
+  } catch (error: any) {
+    // Extract Salesforce error details when available
+    let errorMessage = error instanceof Error ? error.message : String(error);
+
+    // jsforce errors often include the response body with Salesforce error codes
+    if (error.errorCode) {
+      errorMessage = `[${error.errorCode}] ${error.message}`;
+    }
+    if (error.content && Array.isArray(error.content)) {
+      errorMessage = error.content
+        .map((e: any) => `[${e.errorCode}] ${e.message}`)
+        .join('\n');
+    }
+
+    return {
+      content: [{
+        type: "text",
+        text: `${method} ${args.endpoint} — Error\n\n${errorMessage}`
+      }],
+      isError: true,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new `salesforce_rest_api` tool that provides direct access to **any** Salesforce REST API endpoint. This is a generic passthrough that unlocks hundreds of APIs without needing individual tool implementations for each.

### What it enables
- **Reports & Dashboards API** — `GET /analytics/reports/{id}`
- **Composite API** — `POST /composite` (batch multiple operations)
- **Files & ContentDocument** — `GET /sobjects/ContentVersion/{id}/VersionData`
- **Org Limits** — `GET /limits`
- **Approval Processes** — `POST /process/approvals`
- **Tabs, Themes, Quick Actions** — and any other standard REST endpoint
- **Custom Apex REST endpoints** — via `rawPath: true`

### Features
- All HTTP methods: GET, POST, PATCH, PUT, DELETE
- Automatic `/services/data/vXX.0/` prefix (with `rawPath` escape hatch for custom endpoints)
- Configurable API version override per request
- Query parameter support
- JSON request body for mutations
- Large response truncation (50k chars) to prevent client overload
- Salesforce-specific error code extraction from jsforce errors

### Files changed
- `src/tools/restApi.ts` — New tool definition, args interface, and handler
- `src/index.ts` — Import, tool registration, and switch case routing
- `README.md` — Documentation with feature description and usage examples

## Test plan
- [x] TypeScript compiles cleanly (`npm run build`)
- [x] Existing tests pass (`npm test` — 3/3)
- [ ] Manual test: `GET /limits` returns org API usage
- [ ] Manual test: `GET /analytics/reports/{id}` runs a report
- [ ] Manual test: `POST /composite` with composite request body
- [ ] Manual test: `rawPath: true` with custom Apex REST endpoint
- [ ] Manual test: Invalid endpoint returns clear Salesforce error

🤖 Generated with [Claude Code](https://claude.com/claude-code)