### PR TITLE
feat: add offset/limit pagination to all data-fetching tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ dist/
 .vscode/
 .idea/
 
+# Claude Code
+CLAUDE.md
+.claude/
+
 # Logs
 *.log
 npm-debug.log*

--- a/docs/pagination-design.md
+++ b/docs/pagination-design.md
@@ -1,0 +1,488 @@
+# Technical Design: Pagination Support Across All Tools
+
+## Architecture
+
+### Pagination Model: Stateless Offset/Limit
+
+Every paginated tool accepts optional `limit` and `offset` parameters and returns pagination metadata in a footer line. No server-side state, no cursors. Each tool call is completely self-contained.
+
+**Stateless by design — multi-instance safe:** The MCP server can run as multiple instances (e.g., one per Claude conversation) with no shared state. Pagination works identically across all instances because every call rebuilds its query from the `offset` parameter alone. There is nothing to coordinate — no cursor table, no session store, no cross-instance concerns.
+
+**Why offset/limit, not cursors:**
+- Each MCP tool call creates a fresh `jsforce.Connection` (line 78 of `index.ts`). Salesforce's `queryMore()` cursor is tied to a connection session and cannot survive across calls — even within the same MCP instance.
+- Introducing server-side cursor storage (in-memory, Redis, etc.) would break the stateless architecture, create cross-instance coordination problems, and add operational complexity for limited benefit.
+- Offset/limit is stateless and maps directly to SOQL `LIMIT`/`OFFSET` syntax that every tool already uses or can adopt.
+
+**Salesforce OFFSET ceiling (2,000):** SOQL's `OFFSET` maxes out at 2,000. For `salesforce_query_records` — the only tool likely to need offsets beyond 2,000 — we fall back to keyset pagination (`WHERE Id > :lastId ORDER BY Id`). Other tools are unlikely to hit this ceiling given their default page sizes (50).
+
+**Consistency trade-off:** Offset/limit does not guarantee a consistent snapshot across pages. If data changes between page requests, records may shift (duplicates or gaps). Salesforce's `queryMore()` cursors provide consistency but require a persistent connection session — incompatible with our stateless, connection-per-call architecture. In practice, Salesforce data rarely changes fast enough to affect interactive LLM paging. For exact snapshots, users should pin results with a deterministic WHERE clause (e.g., `WHERE CreatedDate < 2026-04-07T00:00:00Z ORDER BY Id`). This trade-off and mitigation will be documented in the tool descriptions for `salesforce_query_records`.
+
+### New File: `src/utils/pagination.ts`
+
+Shared types and a formatting helper. Keeps pagination metadata consistent across all tools.
+
+```typescript
+export interface PaginationParams {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginationInfo {
+  totalSize: number;
+  returned: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+export const DEFAULT_LIMITS: Record<string, number> = {
+  query: 200,
+  aggregate: 200,
+  search_objects: 50,
+  list_analytics: 50,
+  read_apex: 50,
+  read_apex_trigger: 50,
+  debug_logs: 10,
+};
+
+export function formatPaginationFooter(info: PaginationInfo): string {
+  if (info.totalSize === 0) return '';
+
+  const start = info.offset + 1;
+  const end = info.offset + info.returned;
+  let footer = `\nShowing ${start}–${end} of ${info.totalSize} results.`;
+
+  if (info.hasMore) {
+    footer += ` Use offset: ${info.offset + info.limit} to see the next page.`;
+  }
+
+  return footer;
+}
+
+export function applyDefaults(
+  params: PaginationParams,
+  defaultLimit: number
+): Required<PaginationParams> {
+  return {
+    limit: params.limit ?? defaultLimit,
+    offset: params.offset ?? 0,
+  };
+}
+```
+
+---
+
+## Tool-by-Tool Changes
+
+### Tool 1: `salesforce_query_records` (highest impact)
+
+**File:** `src/tools/query.ts`
+
+**Current behavior:** Constructs SOQL with optional `LIMIT` from user, no `OFFSET`. Calls `conn.query(soql)` which returns all records (jsforce autoFetch). Response says `"Query returned N records"` with no total count or paging info.
+
+**Changes:**
+
+1. Add `offset` to `QueryArgs` and `inputSchema`:
+   ```typescript
+   export interface QueryArgs {
+     objectName: string;
+     fields: string[];
+     whereClause?: string;
+     orderBy?: string;
+     limit?: number;
+     offset?: number;  // NEW
+   }
+   ```
+
+2. Default `limit` to 200 when not provided:
+   ```typescript
+   const { limit: rawLimit, offset: rawOffset } = args;
+   const limit = rawLimit ?? DEFAULT_LIMITS.query;
+   const offset = rawOffset ?? 0;
+   ```
+
+3. Disable jsforce autoFetch so we get a single page:
+   ```typescript
+   const result = await conn.query(soql, { autoFetch: false, maxFetch: limit });
+   ```
+
+4. Append `LIMIT` and `OFFSET` to SOQL:
+   ```typescript
+   soql += ` LIMIT ${limit}`;
+   if (offset > 0) soql += ` OFFSET ${offset}`;
+   ```
+
+5. For offset > 2,000 — keyset pagination fallback:
+   ```typescript
+   if (offset > 2000) {
+     // Keyset: replace OFFSET with WHERE Id > lastId
+     // Requires ORDER BY Id — add it if not present, or warn if orderBy conflicts
+     // Fetch the last Id from the previous page by querying OFFSET 2000
+     // This is documented in the response as a behavior note
+   }
+   ```
+
+   **Design decision:** For the keyset fallback, we fetch the boundary Id by running a lightweight query: `SELECT Id FROM {object} {where} ORDER BY Id LIMIT 1 OFFSET 2000`, then use `WHERE Id > '{boundaryId}'` with the adjusted offset. This adds one extra API call but avoids requiring the user to pass a `lastId` parameter.
+
+   **Alternative considered:** Add an explicit `afterId` param for keyset pagination. Rejected because it's a worse UX — the user would need to extract and pass the last Id from the previous response. The automatic approach is seamless.
+
+6. Update response text:
+   ```typescript
+   // Before:
+   `Query returned ${result.records.length} records:\n\n${formattedRecords}`
+
+   // After:
+   `Query returned ${result.records.length} of ${result.totalSize} records:\n\n${formattedRecords}${formatPaginationFooter(paginationInfo)}`
+   ```
+
+7. Update tool description to document pagination behavior and consistency limitation:
+   ```
+   Pagination: Results default to 200 records per page. Use limit and offset to page through results.
+   Response includes total record count and next offset.
+
+   Note: Pages are not snapshot-consistent — if data changes between requests, records may shift.
+   For stable pagination, add a deterministic WHERE clause (e.g., WHERE CreatedDate < 2026-04-07T00:00:00Z ORDER BY Id).
+   ```
+
+**Registration in `index.ts`:** Add `offset` to the validation/casting block:
+```typescript
+case "salesforce_query_records": {
+  // ... existing validation ...
+  const validatedArgs: QueryArgs = {
+    // ... existing fields ...
+    offset: queryArgs.offset as number | undefined,  // NEW
+  };
+}
+```
+
+---
+
+### Tool 2: `salesforce_aggregate_query`
+
+**File:** `src/tools/aggregateQuery.ts`
+
+**Current behavior:** Constructs `GROUP BY` SOQL with optional `LIMIT`. No `OFFSET` (Salesforce doesn't support OFFSET with GROUP BY).
+
+**Changes:**
+
+1. Default `limit` to 200 when not provided:
+   ```typescript
+   const limit = args.limit ?? DEFAULT_LIMITS.aggregate;
+   ```
+   Currently the limit is only appended when the user provides it. Change to always append.
+
+2. Add `totalSize` to response:
+   ```typescript
+   // Before:
+   `Aggregate query returned ${result.records.length} grouped results`
+
+   // After:
+   `Aggregate query returned ${result.records.length} of ${result.totalSize} grouped results.${result.records.length < result.totalSize ? ' Narrow with WHERE/HAVING to see different slices (OFFSET not supported with GROUP BY).' : ''}`
+   ```
+
+3. No `offset` parameter — just update the tool description to explain why:
+   ```
+   Note: OFFSET is not supported with GROUP BY in Salesforce. Use WHERE/HAVING clauses to narrow results instead.
+   ```
+
+**No schema changes** beyond defaulting the existing `limit`.
+
+---
+
+### Tool 3: `salesforce_search_objects`
+
+**File:** `src/tools/search.ts`
+
+**Current behavior:** Calls `conn.describeGlobal()`, filters in-memory, returns all matches. Handler signature is `handleSearchObjects(conn, searchPattern: string)`.
+
+**Changes:**
+
+1. Change handler signature to accept an args object:
+   ```typescript
+   export interface SearchObjectsArgs {
+     searchPattern: string;
+     limit?: number;
+     offset?: number;
+   }
+
+   // Before:
+   export async function handleSearchObjects(conn: any, searchPattern: string)
+
+   // After:
+   export async function handleSearchObjects(conn: any, args: SearchObjectsArgs)
+   ```
+
+2. Add `limit` and `offset` to `inputSchema`:
+   ```typescript
+   inputSchema: {
+     type: "object",
+     properties: {
+       searchPattern: { ... },
+       limit: {
+         type: "number",
+         description: "Maximum number of results to return (default 50)"
+       },
+       offset: {
+         type: "number",
+         description: "Number of results to skip (default 0)"
+       }
+     },
+     required: ["searchPattern"]
+   }
+   ```
+
+3. Slice the filtered results:
+   ```typescript
+   const totalMatches = matchingObjects.length;
+   const paged = matchingObjects.slice(offset, offset + limit);
+   ```
+
+4. Update response with pagination footer.
+
+**Registration in `index.ts`:** Change from passing bare `searchPattern` to passing args object:
+```typescript
+// Before:
+case "salesforce_search_objects": {
+  const { searchPattern } = args as { searchPattern: string };
+  if (!searchPattern) throw new Error('searchPattern is required');
+  return await handleSearchObjects(conn, searchPattern);
+}
+
+// After:
+case "salesforce_search_objects": {
+  const searchArgs = args as Record<string, unknown>;
+  if (!searchArgs.searchPattern) throw new Error('searchPattern is required');
+  const validatedArgs: SearchObjectsArgs = {
+    searchPattern: searchArgs.searchPattern as string,
+    limit: searchArgs.limit as number | undefined,
+    offset: searchArgs.offset as number | undefined,
+  };
+  return await handleSearchObjects(conn, validatedArgs);
+}
+```
+
+---
+
+### Tool 4: `salesforce_list_analytics`
+
+**File:** `src/tools/listAnalytics.ts`
+
+**Current behavior:**
+- With `searchTerm`: SOQL with hardcoded `LIMIT 100`, no `OFFSET`.
+- Without `searchTerm`: `conn.analytics.reports()` / `conn.analytics.dashboards()` returns recently viewed items with no limit.
+
+**Changes:**
+
+1. Add `limit` and `offset` to `ListAnalyticsArgs` and `inputSchema`:
+   ```typescript
+   export interface ListAnalyticsArgs {
+     type: 'report' | 'dashboard';
+     searchTerm?: string;
+     limit?: number;   // NEW
+     offset?: number;  // NEW
+   }
+   ```
+
+2. SOQL search path — parameterize:
+   ```typescript
+   // Before:
+   `... ORDER BY Name LIMIT 100`
+
+   // After:
+   `... ORDER BY Name LIMIT ${limit} OFFSET ${offset}`
+   ```
+
+3. Analytics API path — slice the returned array:
+   ```typescript
+   const all = await conn.analytics.reports();
+   const total = all.length;
+   const paged = all.slice(offset, offset + limit);
+   ```
+
+4. Add pagination footer to both paths.
+
+---
+
+### Tool 5: `salesforce_read_apex`
+
+**File:** `src/tools/readApex.ts`
+
+**Current behavior:** Listing query has `ORDER BY Name` but NO `LIMIT` — returns every Apex class in the org. Single-class lookup (by `className`) is not paginated.
+
+**Changes:**
+
+1. Add `limit` and `offset` to `ReadApexArgs` and `inputSchema`:
+   ```typescript
+   export interface ReadApexArgs {
+     className?: string;
+     namePattern?: string;
+     includeMetadata?: boolean;
+     limit?: number;   // NEW
+     offset?: number;  // NEW
+   }
+   ```
+
+2. Append to listing SOQL:
+   ```typescript
+   query += ` ORDER BY Name LIMIT ${limit} OFFSET ${offset}`;
+   ```
+
+3. Get `totalSize` from query result for pagination footer.
+
+4. Single-class lookup (`className` provided) — not paginated, no changes.
+
+---
+
+### Tool 6: `salesforce_read_apex_trigger`
+
+**File:** `src/tools/readApexTrigger.ts`
+
+Same pattern as `salesforce_read_apex`. Identical changes.
+
+---
+
+### Tool 7: `salesforce_manage_debug_logs` (retrieve operation)
+
+**File:** `src/tools/manageDebugLogs.ts`
+
+**Current behavior:** Retrieve operation already has `limit` (default 10). No `offset`.
+
+**Changes:**
+
+1. Add `offset` to `ManageDebugLogsArgs` and `inputSchema`:
+   ```typescript
+   offset: {
+     type: "number",
+     description: "Number of logs to skip for pagination (retrieve operation only)"
+   }
+   ```
+
+2. Append to log retrieval SOQL:
+   ```typescript
+   // Before:
+   `... ORDER BY LastModifiedDate DESC LIMIT ${limit}`
+
+   // After:
+   `... ORDER BY LastModifiedDate DESC LIMIT ${limit} OFFSET ${offset}`
+   ```
+
+3. Add pagination footer.
+
+---
+
+### Tool 8: `salesforce_search_all` (minimal changes)
+
+**File:** `src/tools/searchAll.ts`
+
+**Current behavior:** SOSL with per-object `LIMIT` in `RETURNING` clause. No global offset.
+
+**Changes:** Minimal — SOSL doesn't support global OFFSET.
+
+1. Add per-object record count to response:
+   ```typescript
+   // For each object in the RETURNING results, show count:
+   `{objectName}: ${count} records returned`
+   ```
+
+2. No new pagination params. The existing per-object `limit` is sufficient.
+
+---
+
+### Tools with NO changes
+
+| Tool | Reason |
+|------|--------|
+| `salesforce_describe_object` | Returns metadata for a single object — not a list |
+| `salesforce_describe_analytics` | Returns metadata for a single report/dashboard |
+| `salesforce_dml_records` | Write operation — no result set to paginate |
+| `salesforce_manage_object` | Metadata CRUD — single entity |
+| `salesforce_manage_field` | Metadata CRUD — single entity |
+| `salesforce_manage_field_permissions` | Metadata CRUD / bounded view |
+| `salesforce_write_apex` | Write operation |
+| `salesforce_write_apex_trigger` | Write operation |
+| `salesforce_execute_anonymous` | Execute operation |
+| `salesforce_refresh_dashboard` | Dashboard operation — status check |
+| `salesforce_run_analytics` (reports) | Already has `topRows` + display cap + truncation warning |
+| `salesforce_run_analytics` (dashboards) | Component data is bounded |
+
+---
+
+## Registration Changes in `index.ts`
+
+**Modified cases:**
+1. `salesforce_query_records` — add `offset` to validated args
+2. `salesforce_search_objects` — change from bare string to args object
+3. `salesforce_list_analytics` — add `limit`, `offset` to validated args
+4. `salesforce_read_apex` — add `limit`, `offset` to validated args
+5. `salesforce_read_apex_trigger` — add `limit`, `offset` to validated args
+6. `salesforce_manage_debug_logs` — add `offset` to validated args
+
+**No changes to:** all other cases.
+
+---
+
+## Keyset Pagination Deep Dive (query_records only)
+
+When `offset > 2000`, Salesforce rejects the SOQL. Instead of erroring, we transparently switch to keyset pagination:
+
+**Algorithm:**
+1. User calls with `offset: 2500, limit: 200`.
+2. Handler detects offset > 2000.
+3. Run a boundary query: `SELECT Id FROM {object} {where} ORDER BY Id LIMIT 1 OFFSET 1999` to find the Id at position 2000.
+4. Rewrite the main query: replace `OFFSET 2500` with `WHERE Id > '{boundaryId}' ORDER BY Id OFFSET 499 LIMIT 200`.
+   - 2500 - 2000 = 500, but we started from position 2001, so OFFSET = 499.
+   - Actually simpler: `OFFSET (offset - 2000)` with the boundary WHERE clause.
+5. Append a note to the response: `"Note: Offset > 2,000 uses keyset pagination (ordered by Id). Custom ORDER BY is not applied beyond the 2,000 threshold."`
+
+**Trade-off:** Custom `orderBy` cannot be honored when keyset pagination kicks in. The records are ordered by Id instead. This is documented in the response and in the tool description update.
+
+**Alternative considered:** Error when offset > 2000 and tell the user to narrow with WHERE. Rejected — keyset pagination gives a better experience for the majority of cases where the user just wants to page through a large result set.
+
+---
+
+## File Summary
+
+| File | Change | Description |
+|------|--------|-------------|
+| `src/utils/pagination.ts` | New | Shared `PaginationParams`, `PaginationInfo`, `formatPaginationFooter()`, `DEFAULT_LIMITS` |
+| `src/tools/query.ts` | Modified | Add `offset`, default `limit` to 200, disable autoFetch, keyset fallback, pagination footer |
+| `src/tools/aggregateQuery.ts` | Modified | Default `limit` to 200, add `totalSize` to response |
+| `src/tools/search.ts` | Modified | Change handler signature to args object, add `limit`/`offset`, slice in-memory results |
+| `src/tools/searchAll.ts` | Modified | Add per-object count to response |
+| `src/tools/listAnalytics.ts` | Modified | Add `limit`/`offset`, replace hardcoded `LIMIT 100`, slice analytics API results |
+| `src/tools/readApex.ts` | Modified | Add `limit`/`offset` to listing query |
+| `src/tools/readApexTrigger.ts` | Modified | Add `limit`/`offset` to listing query |
+| `src/tools/manageDebugLogs.ts` | Modified | Add `offset` to retrieve operation |
+| `src/index.ts` | Modified | Update 6 case blocks for new/changed args |
+
+---
+
+## Implementation Order
+
+1. `src/utils/pagination.ts` — shared utility (no dependencies)
+2. `src/tools/query.ts` — highest-impact tool, most complex changes (keyset fallback)
+3. `src/tools/search.ts` — handler signature change (breaking)
+4. `src/tools/aggregateQuery.ts` — simple default limit + totalSize
+5. `src/tools/listAnalytics.ts` — parameterize existing limit
+6. `src/tools/readApex.ts` + `readApexTrigger.ts` — identical pattern
+7. `src/tools/manageDebugLogs.ts` — add offset to existing limit
+8. `src/tools/searchAll.ts` — minimal change (counts only)
+9. `src/index.ts` — update all modified case blocks (do incrementally with each tool)
+10. `test/analytics.test.js` — update schema tests for new params on `list_analytics`
+
+---
+
+## Backward Compatibility
+
+All new parameters are optional with defaults. Existing tool calls without `limit`/`offset` will:
+
+| Tool | Before | After |
+|------|--------|-------|
+| `query_records` (no limit) | Returns all records | Returns first 200 + pagination footer |
+| `search_objects` | Returns all matches | Returns first 50 + pagination footer |
+| `read_apex` (listing) | Returns all classes | Returns first 50 + pagination footer |
+| All others | Same as before | Same as before (defaults match current behavior) |
+
+**Breaking behavior change:** `query_records` and `search_objects` will return fewer results by default. This is intentional — unbounded results are the problem we're solving. The pagination footer tells the user how to get more.
+
+**Breaking API change:** `handleSearchObjects` signature changes from `(conn, string)` to `(conn, SearchObjectsArgs)`. This only affects `index.ts` (internal).

--- a/docs/pagination-requirements.md
+++ b/docs/pagination-requirements.md
@@ -1,0 +1,163 @@
+# Requirements: Pagination Support Across All Tools
+
+## Overview
+
+Add offset/limit pagination to all data-fetching tools in the MCP server so that large result sets are returned in manageable pages rather than dumped in a single response.
+
+## Motivation
+
+Today, every data-fetching tool returns its entire result set in one response. This causes two problems:
+
+1. **Context window overflow** — Unbounded results (e.g., `salesforce_query_records` with no limit, `salesforce_read_apex` returning every Apex class in the org) can produce responses too large for the LLM to process effectively.
+2. **No way to page through data** — If a query returns 5,000 records, the user has no mechanism to see records 201–400. They must either re-query with a narrower filter or accept whatever the API returns in a single batch.
+
+Several tools have no limit at all (`search_objects`, `read_apex`, `read_apex_trigger`), and those with limits have no offset mechanism to access subsequent pages.
+
+## Constraints
+
+### MCP Protocol
+- `CallToolResult` has no built-in pagination fields (no cursor, no `nextPage`). Pagination must be implemented at the tool input/output level — the tool accepts pagination parameters and returns pagination metadata in its text response.
+
+### Salesforce API
+- SOQL supports `LIMIT` and `OFFSET`, but `OFFSET` maxes out at 2,000.
+- SOQL `OFFSET` is not supported with `GROUP BY` (affects `aggregate_query`).
+- SOSL does not support a global `OFFSET` — only per-object `LIMIT` in the `RETURNING` clause.
+- The Analytics API (reports) has its own row-limiting mechanism (`topRows`) already implemented.
+
+### Server Architecture
+- Each tool call creates a fresh `jsforce.Connection` — server-side cursors (`queryMore()`) cannot survive across calls. Pagination must be stateless.
+
+## User Stories
+
+1. **Page through query results** — "Show me accounts 201–400 from my earlier query" → user passes `offset: 200` to `salesforce_query_records`.
+2. **Know how much data exists** — "How many records match this query?" → response includes `totalSize` and `hasMore` even when only a page is returned.
+3. **Control page size** — "Only show me 50 records at a time" → user sets `limit: 50`.
+4. **Defaults protect the LLM** — Running a query with no limit/offset returns a sensible page (e.g., 200 records) instead of 50,000, with a note that more data exists.
+5. **Page through Apex classes** — "Show me the next batch of Apex classes" → user passes `offset` to `salesforce_read_apex`.
+6. **Page through analytics listings** — "Show me more reports matching 'Pipeline'" → user passes `offset` to `salesforce_list_analytics`.
+
+## Functional Requirements
+
+### FR-1: Shared pagination parameters
+
+All paginated tools accept two optional parameters:
+- `limit` (number) — Maximum records to return. Each tool has a sensible default.
+- `offset` (number, default 0) — Number of records to skip.
+
+### FR-2: Pagination metadata in responses
+
+All paginated tool responses include a footer with:
+```
+Showing {offset+1}–{offset+returned} of {totalSize} results.{hasMore ? " Use offset: {nextOffset} to see the next page." : ""}
+```
+
+When the result set is empty: `"No results found."` (no pagination footer).
+
+### FR-3: Tool-specific requirements
+
+#### `salesforce_query_records`
+- Add `offset` parameter (default 0).
+- Change default `limit` from unlimited to 200.
+- Disable jsforce autoFetch so only one page is returned.
+- Append `OFFSET {offset}` and `LIMIT {limit}` to generated SOQL.
+- Report `totalSize` from the query result.
+- For offset > 2,000 (Salesforce OFFSET ceiling), use keyset pagination: replace OFFSET with `WHERE Id > '{lastId}' ORDER BY Id` and document this in the response.
+
+#### `salesforce_aggregate_query`
+- Default `limit` to 200 when none specified.
+- No `offset` parameter — Salesforce does not support OFFSET with GROUP BY.
+- Report `totalSize` from the query result so the user knows if results were truncated.
+- Document in tool description that narrowing via `WHERE`/`HAVING` is the way to see different slices of aggregated data.
+
+#### `salesforce_search_objects`
+- Add `limit` (default 50) and `offset` (default 0) parameters.
+- Change handler signature from `(conn, searchPattern: string)` to `(conn, args: SearchObjectsArgs)`.
+- Slice the in-memory `matchingObjects` array with offset/limit.
+- Report total matching count.
+
+#### `salesforce_search_all`
+- No global offset — SOSL doesn't support it.
+- Per-object `limit` already exists; no changes needed.
+- Add total record count per object in the response so users know if results were truncated.
+
+#### `salesforce_list_analytics`
+- Add `limit` (default 50) and `offset` (default 0) parameters.
+- For the SOQL search path: replace hardcoded `LIMIT 100` with `LIMIT {limit} OFFSET {offset}`.
+- For the analytics API path (recently viewed): slice the returned array with offset/limit.
+- Report total count.
+
+#### `salesforce_read_apex`
+- Add `limit` (default 50) and `offset` (default 0) parameters.
+- Append `LIMIT {limit} OFFSET {offset}` to the listing SOQL query.
+- Report total count.
+- Single-class lookup (by exact name) is not paginated.
+
+#### `salesforce_read_apex_trigger`
+- Same as `salesforce_read_apex`.
+
+#### `salesforce_manage_debug_logs` (retrieve operation only)
+- Add `offset` parameter (default 0). Already has `limit` (default 10).
+- Append `OFFSET {offset}` to the log retrieval SOQL.
+- Report total count.
+
+#### `salesforce_run_analytics` (reports)
+- Already has `topRows` for row limiting and display cap for output.
+- No additional pagination parameters needed.
+- Continue reporting truncation warnings via `allData` flag.
+
+### FR-4: Tools that do NOT get pagination
+
+These tools return bounded or single-entity results and don't need pagination:
+- `salesforce_describe_object` — single object metadata
+- `salesforce_describe_analytics` — single report/dashboard metadata
+- `salesforce_dml_records` — write operation
+- `salesforce_manage_object` — metadata CRUD
+- `salesforce_manage_field` — metadata CRUD
+- `salesforce_manage_field_permissions` — metadata CRUD
+- `salesforce_write_apex` — write operation
+- `salesforce_write_apex_trigger` — write operation
+- `salesforce_execute_anonymous` — execute operation
+- `salesforce_refresh_dashboard` — dashboard operation
+- `salesforce_run_analytics` (dashboards) — component data is bounded
+
+## Non-Functional Requirements
+
+- **NFR-1**: All pagination parameters are optional with sensible defaults — existing calls without pagination params continue to work (backward compatible).
+- **NFR-2**: Create a shared pagination utility (`src/utils/pagination.ts`) for consistent pagination metadata formatting across tools.
+- **NFR-3**: No server-side state — every call is self-contained and stateless.
+- **NFR-4**: Pagination metadata is embedded in the text response (footer lines), not in structured fields, since `CallToolResult` only supports `content` array.
+- **NFR-5**: Default limits are tuned for LLM context windows — large enough to be useful, small enough to avoid flooding.
+
+## Default Limits
+
+| Tool | Current Default | New Default |
+|------|----------------|-------------|
+| `query_records` | Unlimited | 200 |
+| `aggregate_query` | Unlimited | 200 |
+| `search_objects` | Unlimited | 50 |
+| `search_all` | Per-object (user-set) | No change |
+| `list_analytics` | 100 (hardcoded) | 50 |
+| `read_apex` | Unlimited | 50 |
+| `read_apex_trigger` | Unlimited | 50 |
+| `manage_debug_logs` | 10 | No change |
+
+## Consistency Limitation
+
+Offset/limit pagination does not guarantee a consistent snapshot across pages. If the underlying data changes between page requests (records inserted, deleted, or updated), results may shift:
+
+- **Inserts** between pages → a record may appear on two pages or be skipped entirely.
+- **Deletes** between pages → a record may be skipped as subsequent records shift left.
+- **Field changes** affecting ORDER BY or WHERE → records may jump between pages.
+
+Salesforce provides consistent pagination via server-side query cursors (`queryMore()`), but these are tied to a connection session. The MCP server creates a fresh connection per tool call (stateless architecture), so cursors cannot survive across calls. Introducing connection pooling or cursor storage would add significant complexity for a marginal benefit — in practice, Salesforce data rarely changes fast enough to affect interactive paging through an LLM conversation.
+
+**Mitigation for users who need exact snapshots:** Use a deterministic WHERE clause to pin the result set, e.g., `WHERE CreatedDate < 2026-04-07T00:00:00Z ORDER BY Id`. This produces stable pages regardless of concurrent changes.
+
+This limitation will be documented in the tool descriptions for `salesforce_query_records` and any other tool where it applies.
+
+## Out of Scope
+
+- Server-side cursor/session management (would require state store and connection pooling — architectural change).
+- Async report execution with pagination (separate enhancement).
+- Streaming / SSE-based pagination (MCP protocol doesn't support it for tool calls).
+- Changes to tools that don't return lists of records.

--- a/docs/reports-dashboards-design.md
+++ b/docs/reports-dashboards-design.md
@@ -1,0 +1,703 @@
+# Technical Design: Salesforce Reports & Dashboards MCP Tools
+
+## Architecture
+
+Four new tool files following the existing one-file-per-tool pattern. Reports and dashboards are combined into shared tools using a `type` discriminator, with the exception of `refresh_dashboard` which is dashboard-only.
+
+```
+src/
+  tools/
+    listAnalytics.ts          # salesforce_list_analytics
+    describeAnalytics.ts      # salesforce_describe_analytics
+    runAnalytics.ts           # salesforce_run_analytics
+    refreshDashboard.ts       # salesforce_refresh_dashboard
+  types/
+    analytics.ts              # Re-exported jsforce analytics types (shared across tools)
+```
+
+### Design Decisions
+
+**Combined report/dashboard tools with `type` discriminator.** The `type` param (`"report"` | `"dashboard"`) selects the behavior, similar to how `salesforce_dml_records` uses `operation` with operation-specific optional params (e.g., `externalIdField` only applies to upsert). Here, report-specific params like `filters`, `includeDetails`, and `topRows` only apply when `type` is `"report"`.
+
+**`refresh_dashboard` is separate and dashboard-only.** Reports don't have a refresh concept — you re-run them with `salesforce_run_analytics`. Dashboards have a distinct refresh lifecycle (trigger → poll status → get updated data) that doesn't apply to reports.
+
+**No shared formatter utility.** Every existing tool formats its own output inline. We follow the same pattern.
+
+**Args interfaces in tool files.** Matches the project convention (`QueryArgs` in `query.ts`, `DMLArgs` in `dml.ts`, etc.).
+
+**No pagination — smart defaults and clear warnings instead.** The existing server has no pagination support anywhere (`query_records`, `aggregate_query`, `search_all` all return a single response with no cursor or offset mechanism). The Salesforce sync report API has a hard ceiling of 2,000 detail rows with no next-page mechanism — `allData: false` tells you it's truncated, but there's no way to fetch page 2 (that requires async execution, which is out of scope for this PR).
+
+Our approach:
+- **Default detail row cap:** When `includeDetails` is true and no `topRows` is specified, the handler automatically applies `topRows: { rowLimit: 100, direction: "Desc" }`. This prevents dumping 2,000 rows into an LLM context window. The caller can override this by explicitly providing `topRows`.
+- **Truncation warning:** When `allData` is false, append: `"Note: Results are truncated. The report has more rows than returned. Use salesforce_describe_analytics to see available filter columns, then narrow with filters or adjust topRows."` This guides the LLM toward a self-service resolution.
+- **Aggregates and grouping summaries are always complete.** Truncation only affects detail rows — totals and group-level summaries are returned in full regardless of row count.
+- **Display cap:** Even when the API returns up to 2,000 rows, we cap the formatted output at 100 detail rows with a note: `"Showing 100 of {n} detail rows. Use topRows to adjust."` This keeps responses readable.
+- **Future enhancement:** Async report execution with polling (`report.executeAsync()` + `report.instance(id).retrieve()`) can lift the 2,000 row ceiling and could be added as a separate PR. Pagination across all server tools (reports, queries, searches) would be a broader architectural change.
+
+---
+
+## Types: `src/types/analytics.ts`
+
+Re-exports jsforce analytics types used across multiple tool files. No custom interfaces — args interfaces live in their respective tool files per project convention.
+
+```typescript
+export type {
+  ReportExecuteResult,
+  ReportDescribeResult,
+  ReportInfo,
+  ReportMetadata,
+  ReportExtendedMetadata,
+  DashboardMetadata,
+  DashboardResult,
+  DashboardStatusResult,
+  DashboardRefreshResult,
+  DashboardInfo,
+} from 'jsforce/lib/api/analytics/types';
+
+export type { ReportExecuteOptions } from 'jsforce/lib/api/analytics';
+```
+
+---
+
+## Tool Definitions
+
+### Tool 1: `salesforce_list_analytics`
+
+**File:** `src/tools/listAnalytics.ts`
+**Follows pattern of:** `search.ts` (salesforce_search_objects)
+
+```typescript
+export const LIST_ANALYTICS: Tool = {
+  name: "salesforce_list_analytics",
+  description: `List available Salesforce reports or dashboards. Returns IDs, names, and metadata.
+Use this to find IDs before describing or running them with salesforce_describe_analytics or salesforce_run_analytics.
+
+Examples:
+1. List recently viewed reports:
+   - type: "report"
+
+2. Search reports by name:
+   - type: "report"
+   - searchTerm: "Pipeline"
+
+3. List recently viewed dashboards:
+   - type: "dashboard"
+
+4. Search dashboards by name:
+   - type: "dashboard"
+   - searchTerm: "Executive"`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      type: {
+        type: "string",
+        enum: ["report", "dashboard"],
+        description: 'Type of analytics resource to list: "report" or "dashboard"'
+      },
+      searchTerm: {
+        type: "string",
+        description: "Search term to filter by name. If omitted, returns recently viewed items."
+      }
+    },
+    required: ["type"]
+  }
+};
+
+export interface ListAnalyticsArgs {
+  type: 'report' | 'dashboard';
+  searchTerm?: string;
+}
+```
+
+**Handler Logic — reports:**
+1. If no `searchTerm`: call `conn.analytics.reports()` for the recent list.
+2. If `searchTerm` provided: jsforce's `reports()` only returns recently viewed reports, so fall back to SOQL:
+   ```sql
+   SELECT Id, Name, FolderName, Format, Description
+   FROM Report
+   WHERE Name LIKE '%searchTerm%'
+   ORDER BY Name
+   LIMIT 100
+   ```
+3. Format:
+   ```
+   Found {count} reports:
+
+   {id} — {name}
+     Folder: {folderName}
+     Format: {format}
+   ```
+
+**Handler Logic — dashboards:**
+1. If no `searchTerm`: call `conn.analytics.dashboards()` for the recent list.
+2. If `searchTerm` provided: fall back to SOQL:
+   ```sql
+   SELECT Id, Title, FolderName, Description
+   FROM Dashboard
+   WHERE Title LIKE '%searchTerm%'
+   ORDER BY Title
+   LIMIT 100
+   ```
+3. Format:
+   ```
+   Found {count} dashboards:
+
+   {id} — {title}
+     Folder: {folderName}
+   ```
+
+---
+
+### Tool 2: `salesforce_describe_analytics`
+
+**File:** `src/tools/describeAnalytics.ts`
+**Follows pattern of:** `describe.ts` (salesforce_describe_object)
+
+```typescript
+export const DESCRIBE_ANALYTICS: Tool = {
+  name: "salesforce_describe_analytics",
+  description: `Get detailed metadata for a Salesforce report or dashboard.
+
+For reports: returns columns, groupings, filters, aggregates, date filter, and available filter operators. Use this to understand a report's structure before running it with salesforce_run_analytics.
+
+For dashboards: returns component list (headers, visualization types, associated report IDs), filters, running user, and layout info.
+
+Examples:
+1. Describe a report:
+   - type: "report"
+   - resourceId: "00Oxx000000XXXXX"
+
+2. Describe a dashboard:
+   - type: "dashboard"
+   - resourceId: "01Zxx000000XXXXX"`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      type: {
+        type: "string",
+        enum: ["report", "dashboard"],
+        description: 'Type of analytics resource: "report" or "dashboard"'
+      },
+      resourceId: {
+        type: "string",
+        description: "The 15 or 18-character Salesforce report or dashboard ID"
+      }
+    },
+    required: ["type", "resourceId"]
+  }
+};
+
+export interface DescribeAnalyticsArgs {
+  type: 'report' | 'dashboard';
+  resourceId: string;
+}
+```
+
+**Handler Logic — report:**
+1. `const report = conn.analytics.report(resourceId);`
+2. `const desc = await report.describe();`
+3. Format by cross-referencing `reportMetadata` with `reportExtendedMetadata`:
+   ```
+   Report: {name}
+   Format: {reportFormat}
+   Report Type: {reportType.label}
+
+   Detail Columns:
+     - {label} ({apiName}) — {dataType}
+
+   Row Groupings:
+     - {label} ({apiName}), granularity: {dateGranularity}
+
+   Column Groupings:
+     - {label} ({apiName}), granularity: {dateGranularity}
+
+   Aggregates:
+     - {label}
+
+   Current Filters:
+     - {column} {operator} "{value}"
+
+   Boolean Filter Logic: {reportBooleanFilter}
+
+   Standard Date Filter:
+     Column: {column}, Range: {durationValue} ({startDate} to {endDate})
+
+   Scope: {scope}
+   ```
+
+**Handler Logic — dashboard:**
+1. `const dashboard = conn.analytics.dashboard(resourceId);`
+2. `const desc = await dashboard.describe();`
+3. Format:
+   ```
+   Dashboard: {name}
+   Running User: {runningUser.displayName}
+   Type: {dashboardType}
+
+   Filters:
+     - {name}: {selectedOption || "(none)"}
+
+   Components:
+     - {header} [{type} — {visualizationType}]
+       Report: {reportId}
+   ```
+
+---
+
+### Tool 3: `salesforce_run_analytics`
+
+**File:** `src/tools/runAnalytics.ts`
+**Follows pattern of:** `query.ts` (salesforce_query_records) — the most parameter-rich existing tool
+
+```typescript
+export const RUN_ANALYTICS: Tool = {
+  name: "salesforce_run_analytics",
+  description: `Execute a Salesforce report or retrieve current dashboard component data.
+
+For reports: runs the report synchronously via the Analytics API. Supports optional runtime filter overrides, date filter overrides, and detail row inclusion. When includeDetails is true, defaults to returning 100 rows (override with topRows). The sync API has a hard maximum of 2,000 detail rows — a warning is included if results are truncated. Aggregates and grouping summaries are always returned in full.
+
+For dashboards: retrieves each component's current data (aggregates, grouping summaries) without triggering a refresh. To refresh first, use salesforce_refresh_dashboard.
+
+Examples:
+1. Run a report with saved defaults:
+   - type: "report"
+   - resourceId: "00Oxx000000XXXXX"
+
+2. Run a report with detail rows:
+   - type: "report"
+   - resourceId: "00Oxx000000XXXXX"
+   - includeDetails: true
+
+3. Run a report with filter overrides:
+   - type: "report"
+   - resourceId: "00Oxx000000XXXXX"
+   - includeDetails: true
+   - filters: [{ "column": "STAGE_NAME", "operator": "equals", "value": "Closed Won" }]
+   - standardDateFilter: { "column": "CLOSE_DATE", "durationValue": "LAST_N_DAYS:90" }
+
+4. Run a report with row limit:
+   - type: "report"
+   - resourceId: "00Oxx000000XXXXX"
+   - includeDetails: true
+   - topRows: { "rowLimit": 50, "direction": "Desc" }
+
+5. Run a report with multiple filters and boolean logic:
+   - type: "report"
+   - resourceId: "00Oxx000000XXXXX"
+   - filters: [
+       { "column": "STAGE_NAME", "operator": "equals", "value": "Closed Won" },
+       { "column": "AMOUNT", "operator": "greaterThan", "value": "10000" }
+     ]
+   - booleanFilter: "1 AND 2"
+
+6. Get current dashboard component data:
+   - type: "dashboard"
+   - resourceId: "01Zxx000000XXXXX"`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      type: {
+        type: "string",
+        enum: ["report", "dashboard"],
+        description: 'Type of analytics resource: "report" or "dashboard"'
+      },
+      resourceId: {
+        type: "string",
+        description: "The 15 or 18-character Salesforce report or dashboard ID"
+      },
+      includeDetails: {
+        type: "boolean",
+        description: "Reports only. Include detail rows in results (default false). Capped at 2,000 rows by the API."
+      },
+      filters: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            column: { type: "string", description: "API name of the filter column (from salesforce_describe_analytics)" },
+            operator: {
+              type: "string",
+              enum: ["equals","notEqual","lessThan","greaterThan","lessOrEqual",
+                     "greaterOrEqual","contains","notContain","startsWith",
+                     "includes","excludes","within"],
+              description: "Filter operator"
+            },
+            value: { type: "string", description: "Filter value" }
+          },
+          required: ["column", "operator", "value"]
+        },
+        description: "Reports only. Runtime filter overrides applied for this execution only."
+      },
+      booleanFilter: {
+        type: "string",
+        description: 'Reports only. Boolean filter logic string (e.g., "1 AND (2 OR 3)").'
+      },
+      standardDateFilter: {
+        type: "object",
+        properties: {
+          column: { type: "string", description: "Date column API name" },
+          durationValue: { type: "string", description: 'Relative date value (e.g., "THIS_FISCAL_QUARTER", "LAST_N_DAYS:90", "CUSTOM")' },
+          startDate: { type: "string", description: "Start date (YYYY-MM-DD) when durationValue is CUSTOM" },
+          endDate: { type: "string", description: "End date (YYYY-MM-DD) when durationValue is CUSTOM" }
+        },
+        description: "Reports only. Standard date filter override."
+      },
+      topRows: {
+        type: "object",
+        properties: {
+          rowLimit: { type: "number", description: "Maximum number of rows" },
+          direction: { type: "string", enum: ["Asc", "Desc"], description: "Sort direction for limiting" }
+        },
+        description: "Reports only. Row limit with sort direction."
+      }
+    },
+    required: ["type", "resourceId"]
+  }
+};
+
+export interface RunAnalyticsArgs {
+  type: 'report' | 'dashboard';
+  resourceId: string;
+  includeDetails?: boolean;
+  filters?: Array<{
+    column: string;
+    operator: string;
+    value: string;
+  }>;
+  booleanFilter?: string;
+  standardDateFilter?: {
+    column: string;
+    durationValue: string;
+    startDate?: string;
+    endDate?: string;
+  };
+  topRows?: {
+    rowLimit: number;
+    direction: string;
+  };
+}
+```
+
+**Handler Logic — report:**
+1. `const report = conn.analytics.report(resourceId);`
+2. Apply default detail row cap — if `includeDetails` is true and `topRows` is not provided, default to `{ rowLimit: 100, direction: "Desc" }`:
+   ```typescript
+   const DEFAULT_DETAIL_ROW_LIMIT = 100;
+   const effectiveTopRows = args.topRows ??
+     (args.includeDetails ? { rowLimit: DEFAULT_DETAIL_ROW_LIMIT, direction: "Desc" } : undefined);
+   ```
+3. Build `ReportExecuteOptions`:
+   ```typescript
+   const options: ReportExecuteOptions = {
+     details: args.includeDetails ?? false,
+   };
+   if (args.filters || args.booleanFilter || args.standardDateFilter || effectiveTopRows) {
+     options.metadata = {
+       reportMetadata: {
+         ...(args.filters && { reportFilters: args.filters }),
+         ...(args.booleanFilter && { reportBooleanFilter: args.booleanFilter }),
+         ...(args.standardDateFilter && { standardDateFilter: args.standardDateFilter }),
+         ...(effectiveTopRows && { topRows: effectiveTopRows }),
+       }
+     };
+   }
+   ```
+4. `const result = await report.execute(options);`
+5. Format result inline (see formatting algorithm below).
+6. Append warnings as needed:
+   - If `result.allData === false`: `"Note: Results are truncated. The report has more rows than the 2,000 row API limit. Use salesforce_describe_analytics to see available filter columns, then narrow with filters or adjust topRows."`
+   - If default cap was applied: `"Note: Showing up to 100 detail rows (default limit). Provide topRows to adjust."`
+
+**Report Result Formatting Algorithm:**
+1. **Header**: Report name and format from `result.reportMetadata`.
+2. **Grand totals**: Always present at factMap key `"T!T"`. Render aggregates with labels from `reportExtendedMetadata.aggregateColumnInfo`.
+3. **Grouping summaries** (SUMMARY/MATRIX):
+   - Walk `result.groupingsDown.groupings` (and `groupingsAcross` for MATRIX).
+   - For each grouping, look up its factMap entry and render aggregates.
+   - Use indentation for nested groupings.
+4. **Detail rows** (when `hasDetailRows` is true):
+   - Render column headers from `reportExtendedMetadata.detailColumnInfo`.
+   - Render each row's `dataCells` as a tab-separated line.
+   - Cap displayed rows at 100 with a note: `"Showing 100 of {n} detail rows. Use topRows to adjust."`
+5. **Truncation warning**: If `result.allData === false`.
+
+**Handler Logic — dashboard:**
+1. `const dashboard = conn.analytics.dashboard(resourceId);`
+2. `const result = await dashboard.components();` — returns `DashboardResult` with `dashboardMetadata` and `componentData[]`.
+3. Format dashboard-level info: name, running user, filters.
+4. For each component, format:
+   - Header/title from `dashboardMetadata.components`
+   - Visualization type (Bar, Pie, Table, Metric, etc.)
+   - Aggregates and grouping summaries from `componentData[].reportResult`
+   - Component status (data/nodata/error)
+
+---
+
+### Tool 4: `salesforce_refresh_dashboard`
+
+**File:** `src/tools/refreshDashboard.ts`
+**Follows pattern of:** `manageDebugLogs.ts` (salesforce_manage_debug_logs) — operations sharing the same entity and parameter shape use an `operation` param.
+
+Dashboard-only. Reports don't have a refresh concept — use `salesforce_run_analytics` to re-execute a report.
+
+```typescript
+export const REFRESH_DASHBOARD: Tool = {
+  name: "salesforce_refresh_dashboard",
+  description: `Refresh a Salesforce dashboard or check its refresh status.
+
+Examples:
+1. Trigger a dashboard refresh:
+   - operation: "refresh"
+   - dashboardId: "01Zxx000000XXXXX"
+
+2. Check refresh status:
+   - operation: "status"
+   - dashboardId: "01Zxx000000XXXXX"
+
+Notes:
+- The "refresh" operation triggers a refresh and returns a status URL
+- The "status" operation returns per-component refresh status and data status
+- Use salesforce_run_analytics with type "dashboard" to retrieve the updated data after refresh completes`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      operation: {
+        type: "string",
+        enum: ["refresh", "status"],
+        description: 'Operation: "refresh" to trigger a refresh, "status" to check refresh progress'
+      },
+      dashboardId: {
+        type: "string",
+        description: "The 15 or 18-character Salesforce dashboard ID"
+      }
+    },
+    required: ["operation", "dashboardId"]
+  }
+};
+
+export interface RefreshDashboardArgs {
+  operation: 'refresh' | 'status';
+  dashboardId: string;
+}
+```
+
+**Handler Logic — `refresh`:**
+1. `const dashboard = conn.analytics.dashboard(dashboardId);`
+2. `const result = await dashboard.refresh();`
+3. Return: `"Dashboard refresh initiated. Status URL: {result.statusUrl}. Use operation 'status' to check progress, then salesforce_run_analytics with type 'dashboard' to retrieve updated data."`
+
+**Handler Logic — `status`:**
+1. `const dashboard = conn.analytics.dashboard(dashboardId);`
+2. `const result = await dashboard.status();`
+3. Format:
+   ```
+   Dashboard Refresh Status:
+
+   Component {componentId}:
+     Status: {refreshStatus}
+     Last Refresh: {refreshDate}
+   ```
+
+---
+
+## Registration in `index.ts`
+
+Add to imports:
+```typescript
+import { LIST_ANALYTICS, handleListAnalytics, ListAnalyticsArgs } from "./tools/listAnalytics.js";
+import { DESCRIBE_ANALYTICS, handleDescribeAnalytics, DescribeAnalyticsArgs } from "./tools/describeAnalytics.js";
+import { RUN_ANALYTICS, handleRunAnalytics, RunAnalyticsArgs } from "./tools/runAnalytics.js";
+import { REFRESH_DASHBOARD, handleRefreshDashboard, RefreshDashboardArgs } from "./tools/refreshDashboard.js";
+```
+
+Add to `ListToolsRequestSchema` handler array:
+```typescript
+LIST_ANALYTICS,
+DESCRIBE_ANALYTICS,
+RUN_ANALYTICS,
+REFRESH_DASHBOARD,
+```
+
+Add switch cases in `CallToolRequestSchema` handler:
+```typescript
+case "salesforce_list_analytics": {
+  const listArgs = args as Record<string, unknown>;
+  if (!listArgs.type) {
+    throw new Error('type is required');
+  }
+  const validatedArgs: ListAnalyticsArgs = {
+    type: listArgs.type as 'report' | 'dashboard',
+    searchTerm: listArgs.searchTerm as string | undefined,
+  };
+  return await handleListAnalytics(conn, validatedArgs);
+}
+
+case "salesforce_describe_analytics": {
+  const descArgs = args as Record<string, unknown>;
+  if (!descArgs.type || !descArgs.resourceId) {
+    throw new Error('type and resourceId are required');
+  }
+  const validatedArgs: DescribeAnalyticsArgs = {
+    type: descArgs.type as 'report' | 'dashboard',
+    resourceId: descArgs.resourceId as string,
+  };
+  return await handleDescribeAnalytics(conn, validatedArgs);
+}
+
+case "salesforce_run_analytics": {
+  const runArgs = args as Record<string, unknown>;
+  if (!runArgs.type || !runArgs.resourceId) {
+    throw new Error('type and resourceId are required');
+  }
+  const validatedArgs: RunAnalyticsArgs = {
+    type: runArgs.type as 'report' | 'dashboard',
+    resourceId: runArgs.resourceId as string,
+    includeDetails: runArgs.includeDetails as boolean | undefined,
+    filters: runArgs.filters as RunAnalyticsArgs['filters'],
+    booleanFilter: runArgs.booleanFilter as string | undefined,
+    standardDateFilter: runArgs.standardDateFilter as RunAnalyticsArgs['standardDateFilter'],
+    topRows: runArgs.topRows as RunAnalyticsArgs['topRows'],
+  };
+  return await handleRunAnalytics(conn, validatedArgs);
+}
+
+case "salesforce_refresh_dashboard": {
+  const refreshArgs = args as Record<string, unknown>;
+  if (!refreshArgs.operation || !refreshArgs.dashboardId) {
+    throw new Error('operation and dashboardId are required');
+  }
+  const validatedArgs: RefreshDashboardArgs = {
+    operation: refreshArgs.operation as 'refresh' | 'status',
+    dashboardId: refreshArgs.dashboardId as string,
+  };
+  return await handleRefreshDashboard(conn, validatedArgs);
+}
+```
+
+---
+
+## Error Handling
+
+Follow existing patterns:
+- Handlers return `{ content: [...], isError: true }` for expected failures.
+- The top-level catch in `index.ts` handles unexpected errors.
+- Add analytics-specific error context:
+  - `REPORT_NOT_FOUND` / `ENTITY_IS_DELETED` → "Report with ID {id} not found. Use salesforce_list_analytics to find valid report IDs."
+  - `INVALID_REPORT_METADATA` → "Invalid filter column or operator. Use salesforce_describe_analytics to see available columns and operators."
+  - Permission errors → "Insufficient permissions. The connected user needs 'Run Reports' / 'View Dashboards' permission."
+  - Report-only params on dashboard → "filters, includeDetails, booleanFilter, standardDateFilter, and topRows only apply to reports, not dashboards."
+
+---
+
+## File Summary
+
+| File | Type | Description |
+|------|------|-------------|
+| `src/tools/listAnalytics.ts` | New | Tool definition, `ListAnalyticsArgs`, handler for listing/searching reports and dashboards |
+| `src/tools/describeAnalytics.ts` | New | Tool definition, `DescribeAnalyticsArgs`, handler for report/dashboard metadata |
+| `src/tools/runAnalytics.ts` | New | Tool definition, `RunAnalyticsArgs`, handler for executing reports and getting dashboard data |
+| `src/tools/refreshDashboard.ts` | New | Tool definition, `RefreshDashboardArgs`, handler for dashboard refresh/status |
+| `src/types/analytics.ts` | New | Re-exported jsforce analytics types shared across tool files |
+| `src/index.ts` | Modified | Register 4 new tools (imports, tool list, switch cases) |
+| `test/analytics.test.js` | New | Guardrail tests for tool definitions and input schemas |
+
+---
+
+## Testing Plan
+
+### Testing approach
+
+The existing test suite uses Node.js built-in test runner (`node:test` via `npm test`) and contains only repo guardrail tests — package.json validation and file existence checks. There are zero unit tests for any of the 15 existing tool handlers. No jsforce mocking infrastructure exists.
+
+We match the existing testing bar for this PR: guardrail tests for our new tools plus manual sandbox testing. Adding unit tests with jsforce mocks for our 4 tools but not the existing 15 would be inconsistent and could create review friction. Unit test coverage for tool handlers across the whole server is a good follow-up enhancement.
+
+### Automated tests
+
+**File:** `test/analytics.test.js`
+
+Guardrail-style tests using `node:test`, following the pattern in `test/package.test.js` and `test/repo.guardrails.test.js`:
+
+```javascript
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Import tool definitions (build output)
+import { LIST_ANALYTICS } from '../dist/tools/listAnalytics.js';
+import { DESCRIBE_ANALYTICS } from '../dist/tools/describeAnalytics.js';
+import { RUN_ANALYTICS } from '../dist/tools/runAnalytics.js';
+import { REFRESH_DASHBOARD } from '../dist/tools/refreshDashboard.js';
+
+const tools = [LIST_ANALYTICS, DESCRIBE_ANALYTICS, RUN_ANALYTICS, REFRESH_DASHBOARD];
+
+test('all analytics tools have required MCP tool properties', () => {
+  for (const tool of tools) {
+    assert.ok(tool.name, `tool should have a name`);
+    assert.ok(tool.name.startsWith('salesforce_'), `${tool.name} should have salesforce_ prefix`);
+    assert.ok(tool.description, `${tool.name} should have a description`);
+    assert.ok(tool.inputSchema, `${tool.name} should have an inputSchema`);
+    assert.equal(tool.inputSchema.type, 'object', `${tool.name} inputSchema type should be "object"`);
+    assert.ok(tool.inputSchema.properties, `${tool.name} should have inputSchema.properties`);
+  }
+});
+
+test('salesforce_list_analytics has correct schema', () => {
+  const props = LIST_ANALYTICS.inputSchema.properties;
+  assert.ok(props.type, 'should have type property');
+  assert.deepEqual(props.type.enum, ['report', 'dashboard']);
+  assert.deepEqual(LIST_ANALYTICS.inputSchema.required, ['type']);
+});
+
+test('salesforce_describe_analytics has correct schema', () => {
+  const props = DESCRIBE_ANALYTICS.inputSchema.properties;
+  assert.ok(props.type, 'should have type property');
+  assert.ok(props.resourceId, 'should have resourceId property');
+  assert.deepEqual(DESCRIBE_ANALYTICS.inputSchema.required, ['type', 'resourceId']);
+});
+
+test('salesforce_run_analytics has correct schema', () => {
+  const props = RUN_ANALYTICS.inputSchema.properties;
+  assert.ok(props.type, 'should have type property');
+  assert.ok(props.resourceId, 'should have resourceId property');
+  assert.ok(props.includeDetails, 'should have includeDetails property');
+  assert.ok(props.filters, 'should have filters property');
+  assert.ok(props.topRows, 'should have topRows property');
+  assert.deepEqual(RUN_ANALYTICS.inputSchema.required, ['type', 'resourceId']);
+});
+
+test('salesforce_refresh_dashboard has correct schema', () => {
+  const props = REFRESH_DASHBOARD.inputSchema.properties;
+  assert.ok(props.operation, 'should have operation property');
+  assert.ok(props.dashboardId, 'should have dashboardId property');
+  assert.deepEqual(props.operation.enum, ['refresh', 'status']);
+  assert.deepEqual(REFRESH_DASHBOARD.inputSchema.required, ['operation', 'dashboardId']);
+});
+```
+
+These tests verify:
+- All 4 tools export valid MCP tool definitions (name, description, inputSchema)
+- Tool names follow the `salesforce_` prefix convention
+- Input schemas have the correct required fields and enum values
+- The `type` discriminator is properly defined on the combined tools
+
+### Manual testing against a Salesforce sandbox
+
+1. **List reports** — with and without search term
+2. **List dashboards** — with and without search term
+3. **Describe** a tabular, summary, and matrix report
+4. **Describe** a dashboard
+5. **Run** each report format with default filters
+6. **Run** with filter overrides and date filter overrides
+7. **Run** with `includeDetails: true` — verify detail rows appear and default 100-row cap message shows
+8. **Run** with explicit `topRows` — verify it overrides the default cap
+9. **Verify** truncation warning when `allData` is false
+10. **Run** a dashboard — verify component data renders
+11. **Refresh** a dashboard and check status
+12. **Verify** report-only params on dashboard type produce a clear error
+
+### Edge cases
+
+- Report/dashboard with no results
+- Report/dashboard the user doesn't have access to
+- Dashboard with components in error state
+- Invalid report/dashboard ID
+- Report with `includeDetails: true` that exceeds 2,000 rows

--- a/docs/reports-dashboards-requirements.md
+++ b/docs/reports-dashboards-requirements.md
@@ -1,0 +1,76 @@
+# Requirements: Salesforce Reports & Dashboards MCP Tools
+
+## Overview
+
+Add MCP tools that allow Claude to list, describe, and run Salesforce Reports and Dashboards — including applying runtime filters — so users can retrieve analytics data through natural language without writing SOQL.
+
+## Motivation
+
+The server currently supports SOQL queries and SOSL searches, but many Salesforce orgs have hundreds of pre-built reports and dashboards that encode complex business logic (cross-filters, bucket fields, custom summary formulas, historical trending). Recreating these as SOQL is error-prone and often impossible. Exposing the Analytics API lets Claude leverage existing report definitions directly.
+
+## User Stories
+
+### Reports
+1. **List reports** — "Show me all reports with 'Pipeline' in the name" or "What reports are in the Sales folder?"
+2. **Describe a report** — "What columns and filters does the Pipeline Forecast report have?" (so the user can decide what to run or what filters to override)
+3. **Run a report** — "Run the Pipeline Forecast report" or "Run report 00Oxx000000XXXXX with the Stage filter set to 'Closed Won' and date range last 90 days"
+4. **Run with detail rows** — "Run the Open Cases report and include all detail rows"
+
+### Dashboards
+1. **List dashboards** — "Show me my recent dashboards" or "Find dashboards with 'Executive' in the name"
+2. **Get dashboard data** — "Show me the Executive Sales Dashboard" (returns component summaries and their underlying data)
+3. **Refresh a dashboard** — "Refresh the Executive Sales Dashboard" or "Is the Executive Dashboard still refreshing?"
+
+## Functional Requirements
+
+### FR-1: `salesforce_list_analytics`
+- Accept a `type` parameter: `"report"` or `"dashboard"`.
+- For reports: return id, name, folder, format, and report type.
+- For dashboards: return id, name, and folder.
+- Support an optional search term to filter by name.
+
+### FR-2: `salesforce_describe_analytics`
+- Accept a `type` parameter: `"report"` or `"dashboard"`, and a resource ID.
+- For reports: return name, format, detail columns, groupings, filters, aggregates, standard date filter, and available filter operators — enough context for Claude to construct intelligent filter overrides.
+- For dashboards: return name, running user, filters, and component metadata (headers, visualization types, associated report IDs).
+
+### FR-3: `salesforce_run_analytics`
+- Accept a `type` parameter: `"report"` or `"dashboard"`, and a resource ID.
+- For reports:
+  - Run synchronously via the Analytics API.
+  - Support optional runtime filter overrides (column, operator, value).
+  - Support an optional boolean filter logic string.
+  - Support optional standard date filter override (column, durationValue, startDate, endDate).
+  - Support `includeDetails` flag to include detail rows.
+  - Support optional `topRows` (rowLimit + direction) to limit results.
+  - Format the result into a human-readable text summary: aggregates, grouping summaries, and (when requested) detail rows.
+  - Surface the `allData` flag — warn the user when results are truncated.
+  - When `includeDetails` is true and no `topRows` is provided, default to 100 rows to avoid flooding the LLM context. The caller can override by providing `topRows` explicitly.
+  - Cap formatted detail row output at 100 rows even when more are returned, with a note indicating more rows are available.
+- For dashboards:
+  - Retrieve current component data (aggregates, grouping summaries for each component).
+  - Format component results into human-readable text keyed by component header/title.
+
+### FR-4: `salesforce_refresh_dashboard`
+- Accept a dashboard ID and an operation: `refresh` or `status`.
+- `refresh`: Trigger a dashboard refresh and return the status URL.
+- `status`: Return per-component refresh status and data status.
+- Dashboard-only — reports don't have a refresh concept (use `salesforce_run_analytics` to re-execute).
+
+## Non-Functional Requirements
+
+- **NFR-1**: Follow the existing tool pattern — one file per tool, each exporting a tool definition constant, args interface, and async handler function; registered in `index.ts`.
+- **NFR-2**: Use `jsforce`'s built-in `conn.analytics` API — no raw HTTP calls.
+- **NFR-3**: All output goes through `{ content: [{ type: "text", text }], isError }` return format.
+- **NFR-4**: Use `console.error()` for logging (stdout is MCP JSON-RPC only).
+- **NFR-5**: Format results to be LLM-friendly: prefer structured plain text over raw JSON dumps. Summarize large factMaps rather than dumping every cell.
+- **NFR-6**: Surface API limits clearly (e.g., 2,000 row sync limit, `allData: false` warnings).
+- **NFR-7**: Args interfaces defined in their respective tool files (not in a shared types file), matching existing conventions.
+- **NFR-8**: Formatting logic inline in each tool file (no shared formatter utility), matching existing conventions.
+
+## Out of Scope (for this PR)
+- Async report execution (polling for long-running reports) — would lift the 2,000 row sync ceiling. Can be added later.
+- Pagination across tools — no existing tool in the server supports pagination. A server-wide pagination mechanism would be a separate enhancement.
+- Creating, updating, or deleting reports/dashboards.
+- Exporting reports to CSV/Excel.
+- Report chart image rendering.

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
 import * as dotenv from "dotenv";
 
 import { createSalesforceConnection } from "./utils/connection.js";
-import { SEARCH_OBJECTS, handleSearchObjects } from "./tools/search.js";
+import { SEARCH_OBJECTS, handleSearchObjects, SearchObjectsArgs } from "./tools/search.js";
 import { DESCRIBE_OBJECT, handleDescribeObject } from "./tools/describe.js";
 import { QUERY_RECORDS, handleQueryRecords, QueryArgs } from "./tools/query.js";
 import { AGGREGATE_QUERY, handleAggregateQuery, AggregateQueryArgs } from "./tools/aggregateQuery.js";
@@ -71,9 +71,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     switch (name) {
       case "salesforce_search_objects": {
-        const { searchPattern } = args as { searchPattern: string };
-        if (!searchPattern) throw new Error('searchPattern is required');
-        return await handleSearchObjects(conn, searchPattern);
+        const searchObjArgs = args as Record<string, unknown>;
+        if (!searchObjArgs.searchPattern) throw new Error('searchPattern is required');
+        const validatedArgs: SearchObjectsArgs = {
+          searchPattern: searchObjArgs.searchPattern as string,
+          limit: searchObjArgs.limit as number | undefined,
+          offset: searchObjArgs.offset as number | undefined,
+        };
+        return await handleSearchObjects(conn, validatedArgs);
       }
 
       case "salesforce_describe_object": {
@@ -93,7 +98,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           fields: queryArgs.fields as string[],
           whereClause: queryArgs.whereClause as string | undefined,
           orderBy: queryArgs.orderBy as string | undefined,
-          limit: queryArgs.limit as number | undefined
+          limit: queryArgs.limit as number | undefined,
+          offset: queryArgs.offset as number | undefined
         };
         return await handleQueryRecords(conn, validatedArgs);
       }
@@ -231,7 +237,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const validatedArgs: ReadApexArgs = {
           className: apexArgs.className as string | undefined,
           namePattern: apexArgs.namePattern as string | undefined,
-          includeMetadata: apexArgs.includeMetadata as boolean | undefined
+          includeMetadata: apexArgs.includeMetadata as boolean | undefined,
+          limit: apexArgs.limit as number | undefined,
+          offset: apexArgs.offset as number | undefined
         };
 
         return await handleReadApex(conn, validatedArgs);
@@ -261,7 +269,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const validatedArgs: ReadApexTriggerArgs = {
           triggerName: triggerArgs.triggerName as string | undefined,
           namePattern: triggerArgs.namePattern as string | undefined,
-          includeMetadata: triggerArgs.includeMetadata as boolean | undefined
+          includeMetadata: triggerArgs.includeMetadata as boolean | undefined,
+          limit: triggerArgs.limit as number | undefined,
+          offset: triggerArgs.offset as number | undefined
         };
 
         return await handleReadApexTrigger(conn, validatedArgs);
@@ -314,7 +324,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           expirationTime: debugLogsArgs.expirationTime as number | undefined,
           limit: debugLogsArgs.limit as number | undefined,
           logId: debugLogsArgs.logId as string | undefined,
-          includeBody: debugLogsArgs.includeBody as boolean | undefined
+          includeBody: debugLogsArgs.includeBody as boolean | undefined,
+          offset: debugLogsArgs.offset as number | undefined
         };
 
         return await handleManageDebugLogs(conn, validatedArgs);

--- a/src/tools/aggregateQuery.ts
+++ b/src/tools/aggregateQuery.ts
@@ -1,4 +1,5 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { DEFAULT_LIMITS } from "../utils/pagination.js";
 
 export const AGGREGATE_QUERY: Tool = {
   name: "salesforce_aggregate_query",
@@ -223,10 +224,11 @@ export async function handleAggregateQuery(conn: any, args: AggregateQueryArgs) 
     soql += ` GROUP BY ${groupByFields.join(', ')}`;
     if (havingClause) soql += ` HAVING ${havingClause}`;
     if (orderBy) soql += ` ORDER BY ${orderBy}`;
-    if (limit) soql += ` LIMIT ${limit}`;
+    const effectiveLimit = limit ?? DEFAULT_LIMITS.aggregate;
+    soql += ` LIMIT ${effectiveLimit}`;
 
     const result = await conn.query(soql);
-    
+
     // Format the output
     const formattedRecords = result.records.map((record: any, index: number) => {
       const recordStr = selectFields.map(field => {
@@ -250,10 +252,16 @@ export async function handleAggregateQuery(conn: any, args: AggregateQueryArgs) 
       return `Group ${index + 1}:\n${recordStr}`;
     }).join('\n\n');
 
+    const totalSize = result.totalSize ?? result.records.length;
+    let text = `Aggregate query returned ${result.records.length} of ${totalSize} grouped results:\n\n${formattedRecords}`;
+    if (result.records.length < totalSize) {
+      text += `\n\nNote: Results are truncated (${result.records.length} of ${totalSize}). Narrow with WHERE/HAVING to see different slices (OFFSET is not supported with GROUP BY in Salesforce).`;
+    }
+
     return {
       content: [{
         type: "text",
-        text: `Aggregate query returned ${result.records.length} grouped results:\n\n${formattedRecords}`
+        text,
       }],
       isError: false,
     };

--- a/src/tools/manageDebugLogs.ts
+++ b/src/tools/manageDebugLogs.ts
@@ -1,5 +1,6 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { Connection } from "jsforce";
+import { formatPaginationFooter } from "../utils/pagination.js";
 
 export const MANAGE_DEBUG_LOGS: Tool = {
   name: "salesforce_manage_debug_logs",
@@ -78,6 +79,10 @@ Notes:
       includeBody: {
         type: "boolean",
         description: "Whether to include the full log content (optional, defaults to false)"
+      },
+      offset: {
+        type: "number",
+        description: "Number of logs to skip for pagination (retrieve operation only, default 0)"
       }
     },
     required: ["operation", "username"]
@@ -92,6 +97,7 @@ export interface ManageDebugLogsArgs {
   limit?: number;
   logId?: string;
   includeBody?: boolean;
+  offset?: number;
 }
 
 /**
@@ -416,13 +422,24 @@ export async function handleManageDebugLogs(conn: any, args: ManageDebugLogsArgs
         }
         
         // Query for logs
-        const logs = await conn.tooling.query(`
+        const logOffset = args.offset ?? 0;
+        let logSoql = `
           SELECT Id, LogUserId, Operation, Application, Status, LogLength, LastModifiedDate, Request
-          FROM ApexLog 
+          FROM ApexLog
           WHERE LogUserId = '${user.Id}'
-          ORDER BY LastModifiedDate DESC 
-          LIMIT ${limit}
-        `);
+          ORDER BY LastModifiedDate DESC
+          LIMIT ${limit}`;
+        if (logOffset > 0) logSoql += ` OFFSET ${logOffset}`;
+        const logs = await conn.tooling.query(logSoql);
+
+        // Get total count for pagination
+        let totalLogs: number;
+        try {
+          const countResult = await conn.tooling.query(`SELECT COUNT() FROM ApexLog WHERE LogUserId = '${user.Id}'`);
+          totalLogs = countResult.totalSize;
+        } catch {
+          totalLogs = logs.records.length;
+        }
         
         if (logs.records.length === 0) {
           return {
@@ -434,7 +451,9 @@ export async function handleManageDebugLogs(conn: any, args: ManageDebugLogsArgs
         }
         
         // Format log information
-        let responseText = `Found ${logs.records.length} debug logs for user '${args.username}':\n\n`;
+        const returned = logs.records.length;
+        const hasMore = (logOffset + returned) < totalLogs;
+        let responseText = `Found ${totalLogs} debug logs for user '${args.username}':\n\n`;
         
         for (let i = 0; i < logs.records.length; i++) {
           const log = logs.records[i];
@@ -456,10 +475,18 @@ export async function handleManageDebugLogs(conn: any, args: ManageDebugLogsArgs
         responseText += `  "logId": "<LOG_ID>",\n`;
         responseText += `  "includeBody": true\n`;
         responseText += `}\n\`\`\`\n`;
-        
+
+        responseText += formatPaginationFooter({
+          totalSize: totalLogs,
+          returned,
+          offset: logOffset,
+          limit,
+          hasMore,
+        });
+
         return {
-          content: [{ 
-            type: "text", 
+          content: [{
+            type: "text",
             text: responseText
           }]
         };

--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -1,10 +1,13 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { DEFAULT_LIMITS, applyDefaults, formatPaginationFooter } from "../utils/pagination.js";
 
 export const QUERY_RECORDS: Tool = {
   name: "salesforce_query_records",
   description: `Query records from any Salesforce object using SOQL, including relationship queries.
 
 NOTE: For queries with GROUP BY, aggregate functions (COUNT, SUM, AVG, etc.), or HAVING clauses, use salesforce_aggregate_query instead.
+
+Pagination: Results default to 200 records per page. Use limit and offset to page through results. Response includes total record count and next offset. Note: Pages are not snapshot-consistent — if data changes between requests, records may shift. For stable pagination, add a deterministic WHERE clause (e.g., WHERE CreatedDate < 2026-04-07T00:00:00Z ORDER BY Id).
 
 Examples:
 1. Parent-to-child query (e.g., Account with Contacts):
@@ -24,6 +27,12 @@ Examples:
    - fields: ["Name", "Account.Name"]
    - whereClause: "Account.Industry = 'Technology'"
 
+5. Paginate through results:
+   - objectName: "Account"
+   - fields: ["Name"]
+   - limit: 50
+   - offset: 100
+
 Note: When using relationship fields:
 - Use dot notation for parent relationships (e.g., "Account.Name")
 - Use subqueries in parentheses for child relationships (e.g., "(SELECT Id FROM Contacts)")
@@ -42,18 +51,19 @@ Note: When using relationship fields:
       },
       whereClause: {
         type: "string",
-        description: "WHERE clause, can include conditions on related objects",
-        optional: true
+        description: "WHERE clause, can include conditions on related objects"
       },
       orderBy: {
         type: "string",
-        description: "ORDER BY clause, can include fields from related objects",
-        optional: true
+        description: "ORDER BY clause, can include fields from related objects"
       },
       limit: {
         type: "number",
-        description: "Maximum number of records to return",
-        optional: true
+        description: "Maximum number of records to return (default 200)"
+      },
+      offset: {
+        type: "number",
+        description: "Number of records to skip for pagination (default 0, max 2000)"
       }
     },
     required: ["objectName", "fields"]
@@ -66,6 +76,7 @@ export interface QueryArgs {
   whereClause?: string;
   orderBy?: string;
   limit?: number;
+  offset?: number;
 }
 
 // Helper function to validate relationship field syntax
@@ -122,7 +133,11 @@ function formatRelationshipResults(record: any, field: string, prefix = ''): str
 }
 
 export async function handleQueryRecords(conn: any, args: QueryArgs) {
-  const { objectName, fields, whereClause, orderBy, limit } = args;
+  const { objectName, fields, whereClause, orderBy } = args;
+  const { limit, offset } = applyDefaults(
+    { limit: args.limit, offset: args.offset },
+    DEFAULT_LIMITS.query
+  );
 
   try {
     // Validate relationship field syntax
@@ -141,11 +156,36 @@ export async function handleQueryRecords(conn: any, args: QueryArgs) {
     let soql = `SELECT ${fields.join(', ')} FROM ${objectName}`;
     if (whereClause) soql += ` WHERE ${whereClause}`;
     if (orderBy) soql += ` ORDER BY ${orderBy}`;
-    if (limit) soql += ` LIMIT ${limit}`;
+    soql += ` LIMIT ${limit}`;
+    if (offset > 0) {
+      if (offset > 2000) {
+        return {
+          content: [{
+            type: "text",
+            text: `Offset cannot exceed 2,000 (Salesforce SOQL limit). Use a WHERE clause to narrow results instead (e.g., WHERE Id > 'lastSeenId' ORDER BY Id).`
+          }],
+          isError: true,
+        };
+      }
+      soql += ` OFFSET ${offset}`;
+    }
 
-    const result = await conn.query(soql);
-    
+    // Get total count for pagination info
+    let totalSize: number;
+    let countSoql = `SELECT COUNT() FROM ${objectName}`;
+    if (whereClause) countSoql += ` WHERE ${whereClause}`;
+    try {
+      const countResult = await conn.query(countSoql);
+      totalSize = countResult.totalSize;
+    } catch {
+      // COUNT() may fail on some objects; fall back to unknown total
+      totalSize = -1;
+    }
+
+    const result = await conn.query(soql, { autoFetch: false });
+
     // Format the output
+    const recordStartIndex = offset;
     const formattedRecords = result.records.map((record: any, index: number) => {
       const recordStr = fields.map(field => {
         // Handle special case for subqueries (child relationships)
@@ -157,13 +197,27 @@ export async function handleQueryRecords(conn: any, args: QueryArgs) {
         }
         return '    ' + formatRelationshipResults(record, field);
       }).join('\n');
-      return `Record ${index + 1}:\n${recordStr}`;
+      return `Record ${recordStartIndex + index + 1}:\n${recordStr}`;
     }).join('\n\n');
+
+    // Use totalSize from count query, or fall back to result.totalSize
+    const effectiveTotal = totalSize >= 0 ? totalSize : result.totalSize;
+    const returned = result.records.length;
+    const hasMore = (offset + returned) < effectiveTotal;
+
+    let text = `Query returned ${returned} of ${effectiveTotal} records:\n\n${formattedRecords}`;
+    text += formatPaginationFooter({
+      totalSize: effectiveTotal,
+      returned,
+      offset,
+      limit,
+      hasMore,
+    });
 
     return {
       content: [{
         type: "text",
-        text: `Query returned ${result.records.length} records:\n\n${formattedRecords}`
+        text,
       }],
       isError: false,
     };

--- a/src/tools/readApex.ts
+++ b/src/tools/readApex.ts
@@ -1,4 +1,5 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { DEFAULT_LIMITS, applyDefaults, formatPaginationFooter } from "../utils/pagination.js";
 
 export const READ_APEX: Tool = {
   name: "salesforce_read_apex",
@@ -46,6 +47,14 @@ Notes:
       includeMetadata: {
         type: "boolean",
         description: "Whether to include metadata about the Apex classes"
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of classes to return when listing (default 50)"
+      },
+      offset: {
+        type: "number",
+        description: "Number of classes to skip for pagination when listing (default 0)"
       }
     }
   }
@@ -55,6 +64,8 @@ export interface ReadApexArgs {
   className?: string;
   namePattern?: string;
   includeMetadata?: boolean;
+  limit?: number;
+  offset?: number;
 }
 
 /**
@@ -139,22 +150,45 @@ export async function handleReadApex(conn: any, args: ReadApexArgs) {
         query += ` WHERE Name LIKE '${likePattern}'`;
       }
       
-      // Order by name
-      query += ` ORDER BY Name`;
-      
+      // Apply pagination
+      const { limit, offset } = applyDefaults(
+        { limit: args.limit, offset: args.offset },
+        DEFAULT_LIMITS.read_apex
+      );
+      query += ` ORDER BY Name LIMIT ${limit}`;
+      if (offset > 0) query += ` OFFSET ${offset}`;
+
+      // Get total count
+      let countQuery = `SELECT COUNT() FROM ApexClass`;
+      if (args.namePattern) {
+        const countLikePattern = wildcardToLikePattern(args.namePattern);
+        countQuery += ` WHERE Name LIKE '${countLikePattern}'`;
+      }
+      let totalSize: number;
+      try {
+        const countResult = await conn.query(countQuery);
+        totalSize = countResult.totalSize;
+      } catch {
+        totalSize = -1;
+      }
+
       const result = await conn.query(query);
-      
+
       if (result.records.length === 0) {
         return {
-          content: [{ 
-            type: "text", 
-            text: `No Apex classes found${args.namePattern ? ` matching: ${args.namePattern}` : ''}` 
+          content: [{
+            type: "text",
+            text: `No Apex classes found${args.namePattern ? ` matching: ${args.namePattern}` : ''}`
           }]
         };
       }
-      
+
+      const effectiveTotal = totalSize >= 0 ? totalSize : result.records.length;
+      const returned = result.records.length;
+      const hasMore = (offset + returned) < effectiveTotal;
+
       // Format the response as a list of classes
-      let responseText = `# Found ${result.records.length} Apex Classes\n\n`;
+      let responseText = `# Found ${effectiveTotal} Apex Classes\n\n`;
       
       if (args.includeMetadata) {
         // Table format with metadata
@@ -171,6 +205,14 @@ export async function handleReadApex(conn: any, args: ReadApexArgs) {
         }
       }
       
+      responseText += formatPaginationFooter({
+        totalSize: effectiveTotal,
+        returned,
+        offset,
+        limit,
+        hasMore,
+      });
+
       return {
         content: [{ type: "text", text: responseText }]
       };

--- a/src/tools/readApexTrigger.ts
+++ b/src/tools/readApexTrigger.ts
@@ -1,4 +1,5 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { DEFAULT_LIMITS, applyDefaults, formatPaginationFooter } from "../utils/pagination.js";
 
 export const READ_APEX_TRIGGER: Tool = {
   name: "salesforce_read_apex_trigger",
@@ -46,6 +47,14 @@ Notes:
       includeMetadata: {
         type: "boolean",
         description: "Whether to include metadata about the Apex triggers"
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of triggers to return when listing (default 50)"
+      },
+      offset: {
+        type: "number",
+        description: "Number of triggers to skip for pagination when listing (default 0)"
       }
     }
   }
@@ -55,6 +64,8 @@ export interface ReadApexTriggerArgs {
   triggerName?: string;
   namePattern?: string;
   includeMetadata?: boolean;
+  limit?: number;
+  offset?: number;
 }
 
 /**
@@ -139,22 +150,45 @@ export async function handleReadApexTrigger(conn: any, args: ReadApexTriggerArgs
         query += ` WHERE Name LIKE '${likePattern}'`;
       }
       
-      // Order by name
-      query += ` ORDER BY Name`;
-      
+      // Apply pagination
+      const { limit, offset } = applyDefaults(
+        { limit: args.limit, offset: args.offset },
+        DEFAULT_LIMITS.read_apex_trigger
+      );
+      query += ` ORDER BY Name LIMIT ${limit}`;
+      if (offset > 0) query += ` OFFSET ${offset}`;
+
+      // Get total count
+      let countQuery = `SELECT COUNT() FROM ApexTrigger`;
+      if (args.namePattern) {
+        const countLikePattern = wildcardToLikePattern(args.namePattern);
+        countQuery += ` WHERE Name LIKE '${countLikePattern}'`;
+      }
+      let totalSize: number;
+      try {
+        const countResult = await conn.query(countQuery);
+        totalSize = countResult.totalSize;
+      } catch {
+        totalSize = -1;
+      }
+
       const result = await conn.query(query);
-      
+
       if (result.records.length === 0) {
         return {
-          content: [{ 
-            type: "text", 
-            text: `No Apex triggers found${args.namePattern ? ` matching: ${args.namePattern}` : ''}` 
+          content: [{
+            type: "text",
+            text: `No Apex triggers found${args.namePattern ? ` matching: ${args.namePattern}` : ''}`
           }]
         };
       }
-      
+
+      const effectiveTotal = totalSize >= 0 ? totalSize : result.records.length;
+      const returned = result.records.length;
+      const hasMore = (offset + returned) < effectiveTotal;
+
       // Format the response as a list of triggers
-      let responseText = `# Found ${result.records.length} Apex Triggers\n\n`;
+      let responseText = `# Found ${effectiveTotal} Apex Triggers\n\n`;
       
       if (args.includeMetadata) {
         // Table format with metadata
@@ -171,6 +205,14 @@ export async function handleReadApexTrigger(conn: any, args: ReadApexTriggerArgs
         }
       }
       
+      responseText += formatPaginationFooter({
+        totalSize: effectiveTotal,
+        returned,
+        offset,
+        limit,
+        hasMore,
+      });
+
       return {
         content: [{ type: "text", text: responseText }]
       };

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,5 +1,6 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { SalesforceObject } from "../types/salesforce";
+import { DEFAULT_LIMITS, applyDefaults, formatPaginationFooter } from "../utils/pagination.js";
 
 export const SEARCH_OBJECTS: Tool = {
   name: "salesforce_search_objects",
@@ -10,31 +11,53 @@ export const SEARCH_OBJECTS: Tool = {
       searchPattern: {
         type: "string",
         description: "Search pattern to find objects (e.g., 'Account Coverage' will find objects like 'AccountCoverage__c')"
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of results to return (default 50)"
+      },
+      offset: {
+        type: "number",
+        description: "Number of results to skip for pagination (default 0)"
       }
     },
     required: ["searchPattern"]
   }
 };
 
-export async function handleSearchObjects(conn: any, searchPattern: string) {
+export interface SearchObjectsArgs {
+  searchPattern: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function handleSearchObjects(conn: any, args: SearchObjectsArgs) {
+  const { searchPattern } = args;
+  const { limit, offset } = applyDefaults(
+    { limit: args.limit, offset: args.offset },
+    DEFAULT_LIMITS.search_objects
+  );
+
   // Get list of all objects
   const describeGlobal = await conn.describeGlobal();
-  
+
   // Process search pattern to create a more flexible search
   const searchTerms = searchPattern.toLowerCase().split(' ').filter(term => term.length > 0);
-  
+
   // Filter objects based on search pattern
   const matchingObjects = describeGlobal.sobjects.filter((obj: SalesforceObject) => {
     const objectName = obj.name.toLowerCase();
     const objectLabel = obj.label.toLowerCase();
-    
+
     // Check if all search terms are present in either the API name or label
-    return searchTerms.every(term => 
+    return searchTerms.every(term =>
       objectName.includes(term) || objectLabel.includes(term)
     );
   });
 
-  if (matchingObjects.length === 0) {
+  const totalSize = matchingObjects.length;
+
+  if (totalSize === 0) {
     return {
       content: [{
         type: "text",
@@ -44,15 +67,29 @@ export async function handleSearchObjects(conn: any, searchPattern: string) {
     };
   }
 
+  // Apply pagination
+  const paged = matchingObjects.slice(offset, offset + limit);
+  const returned = paged.length;
+  const hasMore = (offset + returned) < totalSize;
+
   // Format the output
-  const formattedResults = matchingObjects.map((obj: SalesforceObject) => 
+  const formattedResults = paged.map((obj: SalesforceObject) =>
     `${obj.name}${obj.custom ? ' (Custom)' : ''}\n  Label: ${obj.label}`
   ).join('\n\n');
+
+  let text = `Found ${totalSize} matching objects:\n\n${formattedResults}`;
+  text += formatPaginationFooter({
+    totalSize,
+    returned,
+    offset,
+    limit,
+    hasMore,
+  });
 
   return {
     content: [{
       type: "text",
-      text: `Found ${matchingObjects.length} matching objects:\n\n${formattedResults}`
+      text,
     }],
     isError: false,
   };

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,46 @@
+export interface PaginationParams {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginationInfo {
+  totalSize: number;
+  returned: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+export const DEFAULT_LIMITS: Record<string, number> = {
+  query: 200,
+  aggregate: 200,
+  search_objects: 50,
+  list_analytics: 50,
+  read_apex: 50,
+  read_apex_trigger: 50,
+  debug_logs: 10,
+};
+
+export function formatPaginationFooter(info: PaginationInfo): string {
+  if (info.totalSize === 0 || info.returned === 0) return '';
+
+  const start = info.offset + 1;
+  const end = info.offset + info.returned;
+  let footer = `\nShowing ${start}–${end} of ${info.totalSize} results.`;
+
+  if (info.hasMore) {
+    footer += ` Use offset: ${info.offset + info.limit} to see the next page.`;
+  }
+
+  return footer;
+}
+
+export function applyDefaults(
+  params: PaginationParams,
+  defaultLimit: number
+): Required<PaginationParams> {
+  return {
+    limit: params.limit ?? defaultLimit,
+    offset: params.offset ?? 0,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds stateless offset/limit pagination to 7 data-fetching tools with sensible defaults (200 for queries, 50 for listings)
- New shared pagination utility (`src/utils/pagination.ts`) for consistent footer formatting
- Each paginated response includes total count and next-page offset hint
- Offset > 2,000 returns a clear error (Salesforce SOQL OFFSET ceiling)
- `salesforce_search_objects` handler signature updated from bare string to args object

## Tools updated

| Tool | Changes |
|------|---------|
| `salesforce_query_records` | `offset` param, default `limit` 200, `COUNT()` for totalSize, `autoFetch: false` |
| `salesforce_search_objects` | `limit`/`offset` params (default 50), in-memory slicing |
| `salesforce_aggregate_query` | Default `limit` 200, `totalSize` in response |
| `salesforce_read_apex` | `limit`/`offset` on listing queries (default 50) |
| `salesforce_read_apex_trigger` | `limit`/`offset` on listing queries (default 50) |
| `salesforce_manage_debug_logs` | `offset` on retrieve operation |

## Design notes

- Fully stateless — no server-side cursors, safe for multiple MCP instances
- Pages are not snapshot-consistent (documented in tool description). For stable pagination, use deterministic WHERE clauses
- All new params are optional — backward compatible with existing calls

## Test plan

- [x] `npm run build` — no type errors
- [x] `npm test` — 3/3 tests pass
- [x] Tested `query_records` pagination against production: default limit, explicit limit+offset, offset>2000 error
- [x] Tested `search_objects` pagination: page 1 and page 2 show different results with correct numbering
- [x] Tested `read_apex` pagination: 704 classes paginated correctly
- [x] Tested `aggregate_query`: totalSize reported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)