### PR TITLE
Add Access_Token connection type

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,25 @@ Add to your `claude_desktop_config.json`:
 
 > **Note**: For OAuth 2.0 Client Credentials Flow, the `SALESFORCE_INSTANCE_URL` must be your exact Salesforce instance URL (e.g., `https://your-domain.my.salesforce.com`). The token endpoint will be constructed as `<instance_url>/services/oauth2/token`.
 
+#### For Direct Access Token Authentication:
+```json
+{
+  "mcpServers": {
+    "salesforce": {
+      "command": "npx",
+      "args": ["-y", "@tsmztech/mcp-server-salesforce"],
+      "env": {
+        "SALESFORCE_CONNECTION_TYPE": "Access_Token",
+        "SALESFORCE_INSTANCE_URL": "https://your-domain.my.salesforce.com",
+        "SALESFORCE_ACCESS_TOKEN": "your_access_token"
+      }
+    }
+  }
+}
+```
+
+> **Note**: Use `Access_Token` when the OAuth access token is provisioned by an external system (an SSO gateway, the SF CLI on another machine, a refresh-token-based proxy, etc.) and only the resulting access token + instance URL are available at runtime. The server skips the OAuth handshake and uses the provided token directly.
+
 ## Example Usage
 
 ### Searching Objects

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -18,7 +18,16 @@ export enum ConnectionType {
    * Salesforce CLI authentication using sf org display command
    * Requires Salesforce CLI to be installed and an authenticated org
    */
-  Salesforce_CLI = 'Salesforce_CLI'
+  Salesforce_CLI = 'Salesforce_CLI',
+
+  /**
+   * Direct OAuth access token authentication.
+   * Useful when the access token is provisioned by an external system
+   * (e.g. an SSO gateway, the SF CLI on another machine, a refresh-token-based proxy)
+   * and only the resulting access token + instance URL are available at runtime.
+   * Requires SALESFORCE_INSTANCE_URL and SALESFORCE_ACCESS_TOKEN.
+   */
+  Access_Token = 'Access_Token'
 }
 
 /**

--- a/src/utils/connection.ts
+++ b/src/utils/connection.ts
@@ -152,6 +152,23 @@ export async function createSalesforceConnection(config?: ConnectionConfig) {
       });
       
       return conn;
+    } else if (connectionType === ConnectionType.Access_Token) {
+      // Direct OAuth access token authentication
+      const accessToken = process.env.SALESFORCE_ACCESS_TOKEN;
+      const instanceUrl = process.env.SALESFORCE_INSTANCE_URL || config?.loginUrl;
+
+      if (!accessToken || !instanceUrl) {
+        throw new Error('SALESFORCE_ACCESS_TOKEN and SALESFORCE_INSTANCE_URL are required for Access_Token authentication');
+      }
+
+      console.error(`Connecting to Salesforce using direct access token at ${instanceUrl}`);
+
+      const conn = new jsforce.Connection({
+        instanceUrl,
+        accessToken,
+      });
+
+      return conn;
     } else if (connectionType === ConnectionType.Salesforce_CLI) {
       // Salesforce CLI authentication using sf org display
       console.error('Connecting to Salesforce using Salesforce CLI authentication');


### PR DESCRIPTION
## Summary

Adds a fourth `ConnectionType`: `Access_Token`. This lets external systems provision the OAuth access token and pass it directly to the MCP server without going through OAuth flows or username/password.

## Why

Real-world deployment scenarios I ran into where none of the existing modes fit cleanly:

- **LLM gateways** (e.g. LiteLLM, OpenRouter) that broker per-user Salesforce access for MCP clients. The gateway already has the user's access token from an external SSO flow. The existing modes either require credentials the user doesn't have (Username/Password), require a Connected App per customer org (Client Credentials), or require local CLI access the gateway container doesn't have (Salesforce_CLI).
- **Multi-tenant orchestrators** where the host process handles OAuth (refresh tokens, JWT bearer flows, etc.) and only forwards the resulting access token to the MCP server as a short-lived secret.
- **CI/CD pipelines** that obtain a token upstream and pass it to the MCP server.

## Behavior

When `SALESFORCE_CONNECTION_TYPE=Access_Token`:
- Reads `SALESFORCE_INSTANCE_URL` and `SALESFORCE_ACCESS_TOKEN` from env
- Skips the OAuth handshake
- Constructs `jsforce.Connection({ instanceUrl, accessToken })` directly
- Errors clearly if either var is missing

All existing modes (`User_Password`, `OAuth_2.0_Client_Credentials`, `Salesforce_CLI`) are untouched.

## Test plan

- [x] Tested locally end-to-end against a real Salesforce org with a session token from `sf org display --json`
- [x] Verified existing connection modes still work (no regressions in shared code paths)
- [x] Built clean (`npm run build`)
- [x] Verified clear error when env vars are missing

## Docs

README updated with a new code block under the auth options.