### PR TITLE
Add npm metadata for source and issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
     "name": "@tsmztech/mcp-server-salesforce",
     "version": "0.0.6",
     "description": "A Salesforce connector MCP Server.",
+    "homepage": "https://github.com/tsmztech/mcp-server-salesforce#readme",
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/tsmztech/mcp-server-salesforce.git"
+    },
+    "bugs": {
+      "url": "https://github.com/tsmztech/mcp-server-salesforce/issues"
+    },
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "module",
@@ -36,4 +44,3 @@
       "shx": "^0.4.0"
     }
   }
-  


### PR DESCRIPTION
## Summary
- add package-level homepage, repository, and bugs metadata for `@tsmztech/mcp-server-salesforce`
- point npm users directly to the GitHub README, source repository, and issue tracker
- remove the trailing whitespace at EOF in `package.json`

## Validation
- `node -e "const p=require('./package.json'); if(!p.homepage||!p.repository?.url||!p.bugs?.url) process.exit(1);"`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`