### PR TITLE
fix: remove non-standard 'optional' keyword from tool input schemas

### DIFF
--- a/src/tools/aggregateQuery.ts
+++ b/src/tools/aggregateQuery.ts
@@ -65,22 +65,18 @@ Important Rules:
       whereClause: {
         type: "string",
         description: "WHERE clause to filter rows BEFORE grouping (cannot contain aggregate functions)",
-        optional: true
       },
       havingClause: {
         type: "string",
         description: "HAVING clause to filter results AFTER grouping (use for aggregate conditions)",
-        optional: true
       },
       orderBy: {
         type: "string",
         description: "ORDER BY clause - can only use grouped fields or aggregate functions",
-        optional: true
       },
       limit: {
         type: "number",
         description: "Maximum number of grouped results to return",
-        optional: true
       }
     },
     required: ["objectName", "selectFields", "groupByFields"]

--- a/src/tools/dml.ts
+++ b/src/tools/dml.ts
@@ -29,7 +29,6 @@ export const DML_RECORDS: Tool = {
       externalIdField: {
         type: "string",
         description: "External ID field name for upsert operations",
-        optional: true
       }
     },
     required: ["operation", "objectName", "records"]

--- a/src/tools/manageField.ts
+++ b/src/tools/manageField.ts
@@ -29,7 +29,6 @@ export const MANAGE_FIELD: Tool = {
       label: {
         type: "string",
         description: "Label for the field",
-        optional: true
       },
       type: {
         type: "string",
@@ -37,58 +36,47 @@ export const MANAGE_FIELD: Tool = {
                "Phone", "Picklist", "MultiselectPicklist", "Text", "TextArea", "LongTextArea", 
                "Html", "Url", "Lookup", "MasterDetail"],
         description: "Field type (required for create)",
-        optional: true
       },
       required: {
         type: "boolean",
         description: "Whether the field is required",
-        optional: true
       },
       unique: {
         type: "boolean",
         description: "Whether the field value must be unique",
-        optional: true
       },
       externalId: {
         type: "boolean",
         description: "Whether the field is an external ID",
-        optional: true
       },
       length: {
         type: "number",
         description: "Length for text fields",
-        optional: true
       },
       precision: {
         type: "number",
         description: "Precision for numeric fields",
-        optional: true
       },
       scale: {
         type: "number",
         description: "Scale for numeric fields",
-        optional: true
       },
       referenceTo: {
         type: "string",
         description: "API name of the object to reference (for Lookup/MasterDetail)",
-        optional: true
       },
       relationshipLabel: {
         type: "string",
         description: "Label for the relationship (for Lookup/MasterDetail)",
-        optional: true
       },
       relationshipName: {
         type: "string",
         description: "API name for the relationship (for Lookup/MasterDetail)",
-        optional: true
       },
       deleteConstraint: {
         type: "string",
         enum: ["Cascade", "Restrict", "SetNull"],
         description: "Delete constraint for Lookup fields",
-        optional: true
       },
       picklistValues: {
         type: "array",
@@ -96,22 +84,19 @@ export const MANAGE_FIELD: Tool = {
           type: "object",
           properties: {
             label: { type: "string" },
-            isDefault: { type: "boolean", optional: true }
+            isDefault: { type: "boolean" }
           }
         },
         description: "Values for Picklist/MultiselectPicklist fields",
-        optional: true
       },
       description: {
         type: "string",
         description: "Description of the field",
-        optional: true
       },
       grantAccessTo: {
         type: "array",
         items: { type: "string" },
         description: "Profile names to grant field access to (defaults to ['System Administrator'])",
-        optional: true
       }
     },
     required: ["operation", "objectName", "fieldName"]

--- a/src/tools/manageFieldPermissions.ts
+++ b/src/tools/manageFieldPermissions.ts
@@ -31,17 +31,14 @@ export const MANAGE_FIELD_PERMISSIONS: Tool = {
         type: "array",
         items: { type: "string" },
         description: "Names of profiles to grant/revoke access (e.g., ['System Administrator', 'Sales User'])",
-        optional: true
       },
       readable: {
         type: "boolean",
         description: "Grant/revoke read access (default: true)",
-        optional: true
       },
       editable: {
         type: "boolean",
         description: "Grant/revoke edit access (default: true)",
-        optional: true
       }
     },
     required: ["operation", "objectName", "fieldName"]

--- a/src/tools/manageObject.ts
+++ b/src/tools/manageObject.ts
@@ -31,29 +31,24 @@ export const MANAGE_OBJECT: Tool = {
       description: {
         type: "string",
         description: "Description of the object",
-        optional: true
       },
       nameFieldLabel: {
         type: "string",
         description: "Label for the name field",
-        optional: true
       },
       nameFieldType: {
         type: "string",
         enum: ["Text", "AutoNumber"],
         description: "Type of the name field",
-        optional: true
       },
       nameFieldFormat: {
         type: "string",
         description: "Display format for AutoNumber field (e.g., 'A-{0000}')",
-        optional: true
       },
       sharingModel: {
         type: "string",
         enum: ["ReadWrite", "Read", "Private", "ControlledByParent"],
         description: "Sharing model for the object",
-        optional: true
       }
     },
     required: ["operation", "objectName"]

--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -43,17 +43,14 @@ Note: When using relationship fields:
       whereClause: {
         type: "string",
         description: "WHERE clause, can include conditions on related objects",
-        optional: true
       },
       orderBy: {
         type: "string",
         description: "ORDER BY clause, can include fields from related objects",
-        optional: true
       },
       limit: {
         type: "number",
         description: "Maximum number of records to return",
-        optional: true
       }
     },
     required: ["objectName", "fields"]

--- a/src/tools/searchAll.ts
+++ b/src/tools/searchAll.ts
@@ -48,7 +48,6 @@ Notes:
         type: "string",
         enum: ["ALL FIELDS", "NAME FIELDS", "EMAIL FIELDS", "PHONE FIELDS", "SIDEBAR FIELDS"],
         description: "Which fields to search in",
-        optional: true
       },
       objects: {
         type: "array",
@@ -67,17 +66,14 @@ Notes:
             where: {
               type: "string",
               description: "WHERE clause for this object",
-              optional: true
             },
             orderBy: {
               type: "string",
               description: "ORDER BY clause for this object",
-              optional: true
             },
             limit: {
               type: "number",
               description: "Maximum number of records to return for this object",
-              optional: true
             }
           },
           required: ["name", "fields"]
@@ -97,29 +93,24 @@ Notes:
             value: {
               type: "string",
               description: "Value for the WITH clause",
-              optional: true
             },
             fields: {
               type: "array",
               items: { type: "string" },
               description: "Fields for SNIPPET clause",
-              optional: true
             }
           },
           required: ["type"]
         },
         description: "Additional WITH clauses for the search",
-        optional: true
       },
       updateable: {
         type: "boolean",
         description: "Return only updateable records",
-        optional: true
       },
       viewable: {
         type: "boolean",
         description: "Return only viewable records",
-        optional: true
       }
     },
     required: ["searchTerm", "objects"]


### PR DESCRIPTION
## Summary

`optional` is not a standard JSON Schema keyword — optionality is already expressed by a property's absence from the `required` array. Strict MCP clients validate tool input schemas and reject unknown keywords, causing request failures. This was reported in #42; this PR implements the clean fix discussed there: remove the keyword entirely instead of gating it behind an env variable.

## Changes

- Removed all 41 `optional: true` occurrences across 7 tool files (`query`, `aggregateQuery`, `dml`, `searchAll`, `manageObject`, `manageField`, `manageFieldPermissions`)
- No behavioral change: none of the affected properties were listed in `required`, so they remain optional exactly as before

## Validation

- `npm run build` — clean
- `npm test` — 3/3 pass
- stdio smoke test: server lists all 15 tools, served schemas contain zero `optional` keys, stdout remains pure JSON-RPC

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)