### PR TITLE
feat: add SALESFORCE_API_VERSION environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,18 @@ You can connect to Salesforce using one of three authentication methods:
 2. Make sure your org is authenticated and accessible via `sf org display --json` in the root of your Salesforce project.
 3. The server will automatically retrieve the access token and instance url using the CLI.
 
+### Optional: Salesforce API Version
 
+By default, the server uses the jsforce library's default Salesforce API version, which may be too old for newer standard objects (for example, `AccountPlan` requires API version 62.0+ and fails with `sObject type 'AccountPlan' is not supported`). Set the `SALESFORCE_API_VERSION` environment variable to pin a specific version with any authentication method:
+
+```json
+"env": {
+  "SALESFORCE_CONNECTION_TYPE": "...",
+  "SALESFORCE_API_VERSION": "62.0"
+}
+```
+
+The value must look like `"62.0"` (major version dot minor version).
 
 ### Usage with Claude Desktop
 

--- a/src/utils/connection.ts
+++ b/src/utils/connection.ts
@@ -8,6 +8,21 @@ import { promisify } from 'util';
 const execAsync = promisify(exec);
 
 /**
+ * Reads and validates the optional SALESFORCE_API_VERSION environment variable.
+ * jsforce falls back to its internal default when no version is provided, which
+ * can be too old for newer Salesforce objects (e.g. AccountPlan requires 62.0+).
+ * @returns The API version string (e.g. "62.0"), or undefined to use the jsforce default
+ */
+function getApiVersion(): string | undefined {
+  const apiVersion = process.env.SALESFORCE_API_VERSION;
+  if (!apiVersion) return undefined;
+  if (!/^\d+\.\d$/.test(apiVersion)) {
+    throw new Error(`Invalid SALESFORCE_API_VERSION "${apiVersion}". Expected a version like "62.0".`);
+  }
+  return apiVersion;
+}
+
+/**
  * Executes the Salesforce CLI command to get org information
  * @returns Parsed response from sf org display --json command
  */
@@ -148,7 +163,8 @@ export async function createSalesforceConnection(config?: ConnectionConfig) {
       // Create connection with the access token
       const conn = new jsforce.Connection({
         instanceUrl: tokenResponse.instance_url,
-        accessToken: tokenResponse.access_token
+        accessToken: tokenResponse.access_token,
+        version: getApiVersion()
       });
       
       return conn;
@@ -166,6 +182,7 @@ export async function createSalesforceConnection(config?: ConnectionConfig) {
       const conn = new jsforce.Connection({
         instanceUrl,
         accessToken,
+        version: getApiVersion()
       });
 
       return conn;
@@ -179,7 +196,8 @@ export async function createSalesforceConnection(config?: ConnectionConfig) {
       // Create connection with the access token from CLI
       const conn = new jsforce.Connection({
         instanceUrl: orgInfo.result.instanceUrl,
-        accessToken: orgInfo.result.accessToken
+        accessToken: orgInfo.result.accessToken,
+        version: getApiVersion()
       });
       
       console.error(`Connected to Salesforce org: ${orgInfo.result.username} (${orgInfo.result.alias || 'No alias'})`);
@@ -198,7 +216,7 @@ export async function createSalesforceConnection(config?: ConnectionConfig) {
       console.error('Connecting to Salesforce using Username/Password authentication');
       
       // Create connection with login URL
-      const conn = new jsforce.Connection({ loginUrl });
+      const conn = new jsforce.Connection({ loginUrl, version: getApiVersion() });
       
       await conn.login(
         username,


### PR DESCRIPTION
## Summary

Implements #105. jsforce uses its internal default API version when none is specified, which is too old for newer standard Salesforce objects — e.g. `AccountPlan` (API v62.0+) fails with `sObject type 'AccountPlan' is not supported`. This adds an optional `SALESFORCE_API_VERSION` env variable that pins the API version.

## Changes

- New `getApiVersion()` helper in `src/utils/connection.ts`: reads `SALESFORCE_API_VERSION`, validates the format (`62.0`-style), fails fast with a clear error on invalid values, returns `undefined` (jsforce default) when unset
- `version` passed to **all four** connection types: OAuth 2.0 Client Credentials, Access_Token (added in #115, after the issue was filed), Salesforce CLI, and Username/Password
- README: new "Optional: Salesforce API Version" section with example config

## Validation

- `npm run build` — clean
- `npm test` — 3/3 pass
- stdio smoke test: invalid version value surfaces as a clean JSON-RPC error inside the tool response; stdout remains pure JSON-RPC

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)