### PR TITLE
fix: warn when running under bun + document Node runtime requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ An MCP (Model Context Protocol) server implementation that integrates Claude wit
 
 ## Installation
 
+### Requirements
+
+- **Node.js 20+**. The server must run under Node — **bun is not supported**: jsforce's HTTP transport hangs under bun, so authentication appears to succeed but every Salesforce API call stalls until the MCP host times out (see [#118](https://github.com/tsmztech/mcp-server-salesforce/issues/118)). Use `npx`/`node` (not `bun x`) in your MCP client configuration.
+
 ### Global Installation (npm)
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -338,6 +338,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 async function runServer() {
+  // jsforce's HTTP transport hangs under bun: auth succeeds but every query
+  // stalls until the MCP host times out (#118). Warn loudly on stderr.
+  if (process.versions.bun) {
+    console.error(
+      "WARNING: Running under bun is not supported — Salesforce API calls will hang " +
+      "(jsforce's HTTP transport is incompatible with bun). Run with Node 20+ instead, " +
+      "e.g. npx -y @tsmztech/mcp-server-salesforce"
+    );
+  }
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("Salesforce MCP Server running on stdio");


### PR DESCRIPTION
## Summary

Addresses #118. Under **bun**, authentication appears to succeed (the token request uses `node:https` directly, which bun supports) but every subsequent Salesforce API call goes through jsforce's HTTP transport, which hangs indefinitely under bun — the MCP host eventually times out with `Connection closed`. The reporter's diagnosis in #118 is confirmed; this is a jsforce/bun incompatibility, not something we can patch in this codebase without replacing jsforce's transport.

## Changes

- `src/index.ts`: detect bun at startup (`process.versions.bun`) and print a prominent **stderr** warning explaining that API calls will hang and to run under Node instead (stderr only — stdout stays pure JSON-RPC)
- `README.md`: new **Requirements** section documenting Node 20+ and the bun incompatibility, linking to #118

## Validation

- `npm run build` — clean
- `npm test` — 3/3 pass
- Under Node: no warning appears; stdio smoke test unchanged (stdout pure JSON-RPC)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)