### PR TITLE
feat(docker): add container support and documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules/
+dist/
+.git/
+.github/
+test/
+claude-desktop/
+.env
+.env.*
+npm-debug.log*
+*.log
+Dockerfile
+README.md
+LICENSE
+SECURITY.md
+.gitignore
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:20-slim AS build
+FROM node:22-slim AS build
 
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install --ignore-scripts
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
 
 COPY tsconfig.json ./
 COPY src ./src
@@ -11,15 +11,17 @@ COPY src ./src
 RUN npm run build
 
 
-FROM node:20-slim
+FROM node:22-slim
 
 WORKDIR /app
 
 ENV NODE_ENV=production
 
-COPY package.json ./
-RUN npm install --omit=dev --ignore-scripts
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts
 
 COPY --from=build /app/dist ./dist
+
+USER node
 
 CMD ["node", "dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20-slim AS build
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --ignore-scripts
+
+COPY tsconfig.json ./
+COPY src ./src
+
+RUN npm run build
+
+
+FROM node:20-slim
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY package.json ./
+RUN npm install --omit=dev --ignore-scripts
+
+COPY --from=build /app/dist ./dist
+
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -271,6 +271,110 @@ Add to your `claude_desktop_config.json`:
 
 > **Note**: Use `Access_Token` when the OAuth access token is provisioned by an external system (an SSO gateway, the SF CLI on another machine, a refresh-token-based proxy, etc.) and only the resulting access token + instance URL are available at runtime. The server skips the OAuth handshake and uses the provided token directly.
 
+## Running with Docker
+
+You can run this MCP server inside a Docker container. Because the server communicates over `stdio` (standard input/output), the container is typically executed interactively by an MCP client using `docker run -i`.
+
+### 1. Clone the Repo
+
+```bash
+git clone https://github.com/tsmztech/mcp-server-salesforce.git
+```
+
+### 2. Navigate to directory
+```bash
+cd mcp-server-salesforce
+```
+
+### 3. Build the Image
+
+```bash
+docker build -t mcp-server-salesforce .
+```
+
+### 4. Authentication in Containers
+
+> [!NOTE]
+> The Salesforce CLI (`sf`) web-based OAuth login flow is unavailable inside headless Docker containers.
+>
+> When running containerized, use one of the supported environment-variable based authentication methods:
+>
+> - **Username & Password Authentication**
+>   - `SALESFORCE_CONNECTION_TYPE=User_Password`
+>   - `SALESFORCE_USERNAME`
+>   - `SALESFORCE_PASSWORD`
+>   - `SALESFORCE_TOKEN`
+>
+> - **OAuth 2.0 Client Credentials Flow**
+>   - `SALESFORCE_CONNECTION_TYPE=OAuth_2.0_Client_Credentials`
+>   - `SALESFORCE_CLIENT_ID`
+>   - `SALESFORCE_CLIENT_SECRET`
+>   - `SALESFORCE_INSTANCE_URL`
+>
+> - **Direct Access Token Authentication**
+>   - `SALESFORCE_CONNECTION_TYPE=Access_Token`
+>   - `SALESFORCE_ACCESS_TOKEN`
+>   - `SALESFORCE_INSTANCE_URL`
+
+### 5. MCP Client Configuration
+
+To register the containerized server with an MCP client (such as Claude Desktop), add the following configuration to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "salesforce": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "SALESFORCE_CONNECTION_TYPE=User_Password",
+        "-e",
+        "SALESFORCE_USERNAME=your_username",
+        "-e",
+        "SALESFORCE_PASSWORD=your_password",
+        "-e",
+        "SALESFORCE_TOKEN=your_security_token",
+        "mcp-server-salesforce"
+      ]
+    }
+  }
+}
+```
+
+### 6. Manual Testing
+
+You can test the containerized server directly from your terminal:
+
+```bash
+docker run -i --rm \
+  -e SALESFORCE_CONNECTION_TYPE="User_Password" \
+  -e SALESFORCE_USERNAME="your_username" \
+  -e SALESFORCE_PASSWORD="your_password" \
+  -e SALESFORCE_TOKEN="your_security_token" \
+  mcp-server-salesforce
+```
+
+Once the container is running, you can send an MCP `initialize` JSON-RPC request through `stdin`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {
+      "name": "test-client",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
 ## Example Usage
 
 ### Searching Objects


### PR DESCRIPTION
## Summary

This PR introduces containerization support for the Salesforce MCP Server as a focused, single-purpose change. 
It provides a minimal, secure Docker build setup along with documentation for configuring the containerized server with MCP clients using the `stdio` transport.

---

## Changes Included

- **`Dockerfile`**: Implements a two-stage build process using `node:20-slim`.
  - Uses `--ignore-scripts` during installation steps to prevent lifecycle scripts from running before source code is mounted.
  - Installs production-only dependencies in the runner stage to keep the final image minimal.
- **`.dockerignore`**: Excludes `node_modules`, build outputs, test files, local environments, and non-essential documentation from the Docker build context.
- **`README.md`**: Added a dedicated **"Running with Docker"** section covering:
  - Docker build & execution steps.
  - Note on headless execution: explaining why Salesforce CLI (`sf`) auth is unavailable inside containers and detailing alternative environment-variable auth methods (`User_Password`, `OAuth_2.0_Client_Credentials`, `Access_Token`).
  - Configuration snippet for MCP clients (e.g., Claude Desktop) using `docker run -i`.
  - Manual JSON-RPC testing via `stdin`.

---

## Verification & Testing

1. **Build Verification**:
   - Tested clean image compilation via `docker build -t mcp-server-salesforce .`.

2. **`stdio` Stream Purity**:
   - Verified that running `docker run -i --rm mcp-server-salesforce` preserves `stdout` purity for JSON-RPC messages (startup log messages are correctly directed to `stderr`).
   - Verified initialization handshake by sending a test `initialize` payload through `stdin`.

---

## Related Issue

Closes #122 