### PR TITLE
chore: bump codeql-action to 4.37.1 across all workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      # codeql-action subactions (init, autobuild, analyze, upload-sarif) must stay
+      # on the same version or the CodeQL workflow fails with a version mismatch
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,10 +16,10 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v7.0.0
-      - uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7
+      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a
         with:
           languages: javascript
-      - uses: github/codeql-action/autobuild@5d4e8d1aca955e8d8589aabd499c5cae939e33c7
-      - uses: github/codeql-action/analyze@5d4e8d1aca955e8d8589aabd499c5cae939e33c7
+      - uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a
+      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a
         with:
           category: "/language:javascript"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,6 +37,6 @@ jobs:
           path: results.sarif
           retention-days: 5
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Why

Dependabot opened #128 (init), #124 (autobuild), and #126 (upload-sarif) as separate PRs, and has no PR for the analyze action at all. The three actions in codeql.yml must run the same version, so each individual PR fails the CodeQL workflow with:

> Loaded a configuration file for version '4.37.1', but running version '4.31.9'

Merging any subset can never go green; the bump has to land as one commit.

## What

- Bump all four pinned SHAs to v4.37.1 (verified against the upstream tag `7188fc3`): init, autobuild, analyze in codeql.yml, and upload-sarif in scorecard.yml
- Add a Dependabot `groups` rule so future `github/codeql-action` bumps arrive as a single combined PR instead of recreating this situation

Supersedes #128, #124, #126 (will close them after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)