### PR TITLE
Annotate read-only tools with readOnlyHint

### DIFF
--- a/src/tools/aggregateQuery.ts
+++ b/src/tools/aggregateQuery.ts
@@ -80,6 +80,9 @@ Important Rules:
       }
     },
     required: ["objectName", "selectFields", "groupByFields"]
+  },
+  annotations: {
+    readOnlyHint: true
   }
 };
 

--- a/src/tools/describe.ts
+++ b/src/tools/describe.ts
@@ -13,6 +13,9 @@ export const DESCRIBE_OBJECT: Tool = {
       }
     },
     required: ["objectName"]
+  },
+  annotations: {
+    readOnlyHint: true
   }
 };
 

--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -54,6 +54,9 @@ Note: When using relationship fields:
       }
     },
     required: ["objectName", "fields"]
+  },
+  annotations: {
+    readOnlyHint: true
   }
 };
 

--- a/src/tools/readApex.ts
+++ b/src/tools/readApex.ts
@@ -48,6 +48,9 @@ Notes:
         description: "Whether to include metadata about the Apex classes"
       }
     }
+  },
+  annotations: {
+    readOnlyHint: true
   }
 };
 

--- a/src/tools/readApexTrigger.ts
+++ b/src/tools/readApexTrigger.ts
@@ -48,6 +48,9 @@ Notes:
         description: "Whether to include metadata about the Apex triggers"
       }
     }
+  },
+  annotations: {
+    readOnlyHint: true
   }
 };
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -13,6 +13,9 @@ export const SEARCH_OBJECTS: Tool = {
       }
     },
     required: ["searchPattern"]
+  },
+  annotations: {
+    readOnlyHint: true
   }
 };
 

--- a/src/tools/searchAll.ts
+++ b/src/tools/searchAll.ts
@@ -114,6 +114,9 @@ Notes:
       }
     },
     required: ["searchTerm", "objects"]
+  },
+  annotations: {
+    readOnlyHint: true
   }
 };
 


### PR DESCRIPTION
The seven query and describe tools have no `annotations`, so they inherit `readOnlyHint: false`. A client reading the tool list has no way to tell that `salesforce_query_records` only reads, and can prompt the user before running it.

Each of the seven calls exactly one of `conn.query`, `conn.describe`, `conn.describeGlobal`, or `conn.search`:

| tool file | call |
|---|---|
| `query.ts`, `aggregateQuery.ts` | `conn.query` |
| `readApex.ts`, `readApexTrigger.ts` | `conn.query` |
| `describe.ts` | `conn.describe` |
| `search.ts` | `conn.describeGlobal` |
| `searchAll.ts` | `conn.search` |

`salesforce_dml_records`, the Apex write tools, and the metadata tools are untouched, so their defaults stand. I did not set `destructiveHint` anywhere, since it only carries meaning when `readOnlyHint` is false.

`npx tsc --noEmit` passes on this branch.

Three lines per file, no runtime change. If you would rather set these yourself or scope them differently, closing this is completely fine.