### PR TITLE
Release 0.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,12 +44,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.15",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
-      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1347,9 +1347,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1638,9 +1638,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1751,9 +1751,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.2.tgz",
-      "integrity": "sha512-aNJVEVdXTr/g5+N2VCLo+CTrFLo/Y+9rx9RC5BpxPtf7NEknmzY+UQvMO8Fjni5KFmDaHJieL8HCMJKjJXsTgg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tsmztech/mcp-server-salesforce",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tsmztech/mcp-server-salesforce",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tsmztech/mcp-server-salesforce",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "A Salesforce connector MCP Server.",
     "homepage": "https://github.com/tsmztech/mcp-server-salesforce#readme",
     "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import * as dotenv from "dotenv";
+import { readFileSync } from "fs";
 
 import { createSalesforceConnection } from "./utils/connection.js";
 import { SEARCH_OBJECTS, handleSearchObjects } from "./tools/search.js";
@@ -29,10 +30,15 @@ import { MANAGE_DEBUG_LOGS, handleManageDebugLogs, ManageDebugLogsArgs } from ".
 // MCP servers require stdout to contain ONLY JSON-RPC messages
 dotenv.config();
 
+// Report the real package version to MCP clients (dist/index.js lives one level below package.json)
+const { version: packageVersion } = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+);
+
 const server = new Server(
   {
     name: "salesforce-mcp-server",
-    version: "1.0.0",
+    version: packageVersion,
   },
   {
     capabilities: {


### PR DESCRIPTION
## Release 0.0.7

Version bump plus two release-scoped fixes.

### Changes

1. **Version bump to 0.0.7** in package.json and package-lock.json (3 lines).
2. **Report the real package version to MCP clients**: serverInfo.version was hardcoded to "1.0.0" since the first release. The server now reads the version from package.json at startup, so clients see the true release version from now on.
3. **Security: patch 4 transitive vulnerabilities via in-range lockfile bumps** (all transitive via the MCP SDK HTTP transport stack, which this stdio-only server does not use):
   - fast-uri 3.1.4 to 3.1.5 (GHSA-7p8r-x3mc-p8w7, high)
   - ip-address 10.2.2 to 10.4.0 (GHSA-mwp4-54f8-5fhr, high)
   - hono 4.12.32 to 4.13.1 (GHSA-8j4g-w8fx-2239, medium)
   - @hono/node-server 1.19.15 to 2.1.0 (GHSA-frvp-7c67-39w9, moderate; the SDK declares "^1.19.9 || ^2.0.5" so 2.x is in-range)

### Validation

- npm ci, build, 3/3 tests pass
- npm audit: 0 vulnerabilities
- Stdio smoke test: stdout is pure JSON-RPC, 15 tools, 7 readOnlyHint annotations, serverInfo reports 0.0.7, stderr only the startup line
- npm pack: 45 files (LICENSE, README, package.json, dist), shebang and exec bit intact
- Real-install test: extracted the tarball, installed production deps, server runs and reports 0.0.7

After merge: npm publish 0.0.7, then tag v0.0.7 and create the first GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)