### PR TITLE
fix: patch fast-uri and qs transitive vulnerabilities via in-range lockfile bumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1347,9 +1347,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -2320,9 +2320,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
## Summary

Closes the five Dependabot alerts opened on 2026-09-03 (#10, #11, #12, #13, #14). All are transitive dependencies pulled in by the MCP SDK's HTTP transport stack, which this stdio-only server never loads. This is the same lockfile-only approach as #143 (commit a5779f0).

| Package | Before | After | Advisories |
|---|---|---|---|
| fast-uri (via ajv) | 3.1.5 | 3.1.7 | GHSA-5jgf-p345-68v8, GHSA-fph4-wmhf-6fwf, GHSA-f65p-4m7j-42xc, GHSA-jqff-g426-hqxp (all high) |
| qs (via express / body-parser) | 6.15.3 | 6.16.0 | GHSA-x5fp-wj9c-mxmx (medium), GHSA-4mjr-xmp4-gh2g (moderate) |

Both bumps are within the ranges declared by their parents (`ajv` wants `fast-uri@^3.0.1`; `express` and `body-parser` want `qs@^6.15.2` / `^6.14.0`), so `package.json` is untouched and the diff is six lines in `package-lock.json`.

## Exposure

Low in practice. The fast-uri advisories are SSRF / host-confusion bugs in URL normalization and the qs advisory is a query-string parsing limit bypass. The server uses `StdioServerTransport` only and never parses attacker-supplied URLs or HTTP bodies, so none of these paths are reachable. The fix is for hygiene and OpenSSF Scorecard posture.

## Validation

- `npm audit`: 0 vulnerabilities (was 1 high, 1 moderate)
- `npm run build`: clean
- `npm test`: 3 passed, 0 failed
- stdio smoke test (`initialize` + `tools/list`): exactly two JSON-RPC lines on stdout, 15 tools returned, the only log line goes to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
